### PR TITLE
MANTA-4731 rebalancer should expose a REST API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,5 +69,5 @@ diesel = { git = 'https://github.com/diesel-rs/diesel' }
 diesel_derives = { git = "https://github.com/diesel-rs/diesel" }
 
 [[bin]]
-name = "server"
-path = "src/server.rs"
+name = "rebalancer-manager"
+path = "src/manager.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ bytes = "0.4.12"
 strum = "0.16.0"
 strum_macros = "0.16.0"
 
+# We don't use this directly, but gotham pulls it in via the rust-url crate.
+# If we don't specify the exact version here cargo will bring in a newer version
+# that is not compatible with rust 1.35.
+unicode-normalization = "=0.1.5"
 
 diesel = {version = "1.4.2", features = ["sqlite", "postgres"]}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,7 @@ unescape = "0.1.0"
 [patch.crates-io]
 diesel = { git = 'https://github.com/diesel-rs/diesel' }
 diesel_derives = { git = "https://github.com/diesel-rs/diesel" }
+
+[[bin]]
+name = "server"
+path = "src/server.rs"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ cargo clippy
 cargo test
 ```
 
+
 ## Testing
 
 There is a certain flavor of the rebalancer agent that allow for more convenient
@@ -98,3 +99,15 @@ cargo build --features "always_pass"
 ```
 
 Note: By default, this feature will never be enabled.
+
+### Testing certain modules
+* To test only a certain module (including all of its submodules:
+```
+cargo test <module name>
+```
+
+* To test only the REST API server:
+```
+cargo test --bin server
+```
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,7 +86,6 @@ pub struct Command {
 }
 
 impl Command {
-
     pub fn new() -> Result<Command, Error> {
         let mut subcommand = SubCommand::Server;
 

--- a/src/jobs/evacuate.rs
+++ b/src/jobs/evacuate.rs
@@ -400,7 +400,7 @@ impl EvacuateJob {
         }
     }
 
-    fn create_table(&self) -> Result<usize, Error> {
+    pub fn create_table(&self) -> Result<usize, Error> {
         let conn = self.conn.lock().expect("DB conn lock");
         create_evacuateobjects_table(&*conn)
     }

--- a/src/jobs/status.rs
+++ b/src/jobs/status.rs
@@ -80,7 +80,6 @@ pub fn list_jobs() -> Result<Vec<String>, StatusError> {
             return Err(StatusError::Unknown);
         }
     };
-
     let mut ret = vec![];
 
     for db in db_list {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,6 @@ pub mod agent;
 pub mod config;
 pub mod error;
 pub mod jobs;
-pub(crate) mod moray_client;
+pub mod moray_client;
 pub mod pg_db;
 pub mod picker;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -189,7 +189,6 @@ impl Default for JobActionPayload {
 struct EvacuateJobPayload {
     from_shark: MantaObjectShark,
     domain_name: Option<String>,
-    //max_objects: Option<String>,
     max_objects: Option<u32>,
 }
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -188,6 +188,7 @@ pub trait SharkSource: Sync + Send {
 
 // Use our prototype picker zone for now.  Might change this to a shard 1 moray
 // client in the future.
+// TODO: MANTA-4555
 fn fetch_sharks(address: &str) -> Vec<StorageNode> {
     let mut ret = reqwest::get(address).unwrap();
     let result = ret.json::<HashMap<String, Vec<StorageNode>>>().unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,79 @@
+
+#[macro_use]
+extern crate gotham_derive;
+
+#[macro_use]
+extern crate serde_derive;
+
+use std::collections::HashMap;
+
+use remora::jobs::status;
+
+use gotham::router::Router;
+use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
+use gotham::state::{State, FromState};
+
+use hyper::{Body, Response, StatusCode};
+use gotham::helpers::http::response::create_response;
+
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct GetJobParams {
+    uuid: String,
+}
+
+struct JobStatus {
+    status: HashMap<String, String>
+}
+
+impl IntoResponse for JobStatus {
+    fn into_response(self, state: &State) -> Response<Body> {
+        create_response(
+            &state,
+            StatusCode::OK,
+            mime::APPLICATION_JSON,
+            serde_json::to_string(&self)
+                .expect("serialized Job Status")
+        )
+
+    }
+}
+fn get_job(mut state: State) -> (State, Response<Body>) {
+    let get_job_params = GetJobParams::take_from(&mut state);
+    let body = format!("\"ret\": \"{}\"", get_job_params.uuid);
+
+    let response = JobStatus {
+
+    }
+
+    (state, response)
+}
+fn router() -> Router {
+    build_simple_router(|route| {
+        route.get("/jobs/:uuid")
+            .with_path_extractor::<GetJobParams>()
+            .to(get_job)
+    })
+}
+
+fn main() {
+    let addr = "0.0.0.0:8888";
+    gotham::start(addr, router())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gotham::test::TestServer;
+
+    #[test]
+    fn basic() {
+        let test_server = TestServer::new(router()).unwrap();
+        let response = test_server
+            .client()
+            .get("http://localhost:8888/jobs/foo")
+            .perform()
+            .unwrap();
+
+        println!("{:?}", response.read_utf8_body().unwrap());
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,3 @@
-
 #[macro_use]
 extern crate gotham_derive;
 
@@ -7,22 +6,29 @@ extern crate serde_derive;
 
 use std::collections::HashMap;
 
-use remora::jobs::status;
+use remora::jobs;
 
+use gotham::handler::IntoResponse;
+use gotham::helpers::http::response::create_response;
 use gotham::router::Router;
 use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
 use gotham::state::{State, FromState};
-
 use hyper::{Body, Response, StatusCode};
-use gotham::helpers::http::response::create_response;
+use uuid::Uuid;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct GetJobParams {
     uuid: String,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
 struct JobStatus {
-    status: HashMap<String, String>
+    status: HashMap<String, usize>
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct JobList {
+    jobs: Vec<String>
 }
 
 impl IntoResponse for JobStatus {
@@ -34,24 +40,57 @@ impl IntoResponse for JobStatus {
             serde_json::to_string(&self)
                 .expect("serialized Job Status")
         )
-
     }
 }
-fn get_job(mut state: State) -> (State, Response<Body>) {
+
+fn get_job(mut state: State) -> (State, JobStatus) {
     let get_job_params = GetJobParams::take_from(&mut state);
-    let body = format!("\"ret\": \"{}\"", get_job_params.uuid);
+    let uuid = Uuid::parse_str(&get_job_params.uuid).expect("valid uuid");
+    let status = jobs::status::get_status(uuid).expect("valid job");
 
-    let response = JobStatus {
-
-    }
+    let response = JobStatus { status };
 
     (state, response)
 }
+
+impl IntoResponse for JobList {
+    fn into_response(self, state: &State) -> Response<Body> {
+        create_response(
+            &state,
+            StatusCode::OK,
+            mime::APPLICATION_JSON,
+            serde_json::to_string(&self)
+                .expect("serialized Job Status")
+        )
+    }
+}
+
+fn list_jobs(state: State) -> (State, JobList) {
+    let response = JobList {
+        jobs: jobs::status::list_jobs().unwrap()
+    };
+
+    (state, response)
+}
+
+fn create_job(mut state: State) -> (State, String) {
+    let request = Body::take_from(&mut state);
+
+    // TODO
+
+    (state, Uuid::new_v4().to_string())
+
+}
+
 fn router() -> Router {
     build_simple_router(|route| {
         route.get("/jobs/:uuid")
             .with_path_extractor::<GetJobParams>()
-            .to(get_job)
+            .to(get_job);
+        route.get("/jobs")
+            .to(list_jobs);
+        route.post("/jobs")
+            .to(create_job);
     })
 }
 
@@ -68,12 +107,31 @@ mod tests {
     #[test]
     fn basic() {
         let test_server = TestServer::new(router()).unwrap();
+
         let response = test_server
             .client()
-            .get("http://localhost:8888/jobs/foo")
+            .get("http://localhost:8888/jobs")
             .perform()
             .unwrap();
 
-        println!("{:?}", response.read_utf8_body().unwrap());
+        let jobs_ret = response.read_body().unwrap();
+        let job_list: JobList = serde_json::from_slice(&jobs_ret).unwrap();
+
+        println!("{:#?}", job_list);
+
+        let get_this_job = job_list.jobs[0].clone();
+        let get_job_uri = format!("http://localhost:8888/jobs/{}",
+                                  get_this_job);
+
+        let response = test_server
+            .client()
+            .get(get_job_uri)
+            .perform()
+            .unwrap();
+
+
+        let ret = response.read_body().unwrap();
+        let pretty_response: JobStatus = serde_json::from_slice(&ret).unwrap();
+        println!("{:#?}", pretty_response);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -75,6 +75,7 @@ fn get_job(mut state: State) -> (State, Response<Body>) {
         Ok(s) => s,
         Err(e) => {
             let ret: Response<Body>;
+            remora::error!("Get Status error: {:?}", e);
             match e {
                 StatusError::DBExists => {
                     ret = bad_request(
@@ -82,10 +83,10 @@ fn get_job(mut state: State) -> (State, Response<Body>) {
                         format!("Could not find job UUID: {}", uuid),
                     );
                 }
-                StatusError::LookupError => {
+                StatusError::LookupError | StatusError::Unknown => {
                     ret = invalid_server_error(
                         &state,
-                        String::from("Job Database Error"),
+                        String::from("Internal Lookup Error"),
                     );
                 }
             }
@@ -132,7 +133,7 @@ fn list_jobs(state: State) -> (State, Response<Body>) {
             )
         }
         Err(e) => {
-            let msg = format!("Error Getting Job List: {}", e);
+            let msg = format!("Error Getting Job List: {:#?}", e);
             let ret = invalid_server_error(&state, msg);
             return (state, ret);
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -116,7 +116,7 @@ impl Default for JobActionPayload {
 
 #[derive(Serialize, Deserialize, Default)]
 struct EvacuateJobPayload {
-    from_shark: String,
+    from_shark: MantaObjectShark,
     domain_name: Option<String>,
     max_objects: Option<String>,
 }
@@ -258,10 +258,13 @@ impl Handler for JobCreateHandler {
 
                 // TODO: We are temporarily faking a shark for
                 // testing
+                let shark = evac_payload.from_shark;
+                /*
                 let shark = MantaObjectShark {
                     manta_storage_id: evac_payload.from_shark.clone(),
                     datacenter: String::from("Somefakedc"),
                 };
+                */
                 /*
                 let shark moray_client::get_manta_object_shark (
                     &evac_payload.from_shark,
@@ -366,7 +369,10 @@ mod tests {
         let test_server = TestServer::new(router()).unwrap();
         let action_payload = EvacuateJobPayload {
             domain_name: Some(String::from("fake.joyent.us")),
-            from_shark: String::from("fake_shark"),
+            from_shark: MantaObjectShark {
+                manta_storage_id: String::from("fake_storage_id"),
+                datacenter: String::from("fake_datacenter"),
+            },
             max_objects: None,
         };
 
@@ -395,8 +401,5 @@ mod tests {
         }
         let ret = response.read_utf8_body().unwrap();
         println!("{:#?}", ret);
-
-        //let pretty_response: String = serde_json::from_slice(&ret).unwrap();
-        //println!("{:#?}", pretty_response);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,15 +6,25 @@ extern crate serde_derive;
 
 use std::collections::HashMap;
 
-use remora::jobs;
+use remora::jobs::{self, JobAction};
+use remora::config;
+use remora::moray_client;
+use remora::util;
 
-use gotham::handler::IntoResponse;
+use crossbeam_channel;
+use gotham::handler::{IntoResponse, NewHandler, Handler, HandlerFuture, IntoHandlerError};
 use gotham::helpers::http::response::create_response;
 use gotham::router::Router;
 use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
 use gotham::state::{State, FromState};
 use hyper::{Body, Response, StatusCode};
 use uuid::Uuid;
+use threadpool::ThreadPool;
+use futures::{Stream, Future, future};
+use remora::jobs::evacuate::EvacuateJob;
+use libmanta::moray::MantaObjectShark;
+
+static THREAD_COUNT: usize = 1;
 
 #[derive(Deserialize, StateData, StaticResponseExtender)]
 struct GetJobParams {
@@ -73,16 +83,165 @@ fn list_jobs(state: State) -> (State, JobList) {
     (state, response)
 }
 
+/*
 fn create_job(mut state: State) -> (State, String) {
     let request = Body::take_from(&mut state);
 
-    // TODO
+
+    config::Config::parse_config(None)
 
     (state, Uuid::new_v4().to_string())
 
 }
+*/
+
+// TODO this needs to change to be more accomodating for future jobs.
+#[derive(Serialize, Deserialize, Default)]
+struct JobPayload {
+    action: JobActionPayload,
+}
+
+#[derive(Serialize, Deserialize)]
+enum JobActionPayload {
+    Evacuate(EvacuateJobPayload)
+}
+
+impl Default for JobActionPayload {
+    fn default() -> Self {
+        JobActionPayload::Evacuate(EvacuateJobPayload::default())
+    }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct EvacuateJobPayload {
+    from_shark: String,
+    domain_name: Option<String>,
+    max_objects: Option<String>,
+}
+
+#[derive(Clone)]
+struct JobCreateHandler {
+    tx: crossbeam_channel::Sender<jobs::Job>
+}
+
+impl NewHandler for JobCreateHandler {
+    type Instance = Self;
+
+    fn new_handler(&self)  -> gotham::error::Result<Self::Instance> {
+        Ok(self.clone())
+    }
+}
+
+impl Handler for JobCreateHandler {
+    fn handle(self, mut state: State) -> Box<HandlerFuture> {
+        // here rui
+        let config = config::Config::parse_config(None).expect("Config parse");
+        let mut job = jobs::Job::new(config.clone());
+        let job_uuid = job.get_id().to_string();
+
+        let f = Body::take_from(&mut state)
+            .concat2()
+            .then(move |body| match body {
+                Ok(valid_body) => {
+                    let payload:JobPayload = serde_json::from_slice(&valid_body
+                        .into_bytes()).expect("Bad Payload");
+
+                    match payload.action {
+                        JobActionPayload::Evacuate(evac_payload) => {
+                            let domain_name = evac_payload.domain_name
+                                .unwrap_or(config.domain_name.clone());
+                            let max_objects = match evac_payload.max_objects {
+                                Some(str_val) => {
+
+                                    // TODO
+                                    let val: u32 = str_val.parse().expect
+                                    ("max obj parse");
+
+                                    if val == 0 {
+                                        None
+                                    } else {
+                                        Some(val)
+                                    }
+                                },
+                                None => {
+                                    Some(10) // Default
+                                }
+                            };
+
+                            // TODO: We are temporarily faking a shark for
+                            // testing
+                            let shark = MantaObjectShark {
+                                manta_storage_id: evac_payload
+                                    .from_shark.clone(),
+                                datacenter: String::from
+                                    ("Somefakedc")
+
+                            };
+                            /*
+                                match moray_client::get_manta_object_shark (
+                                &evac_payload.from_shark,
+                                &domain_name) {
+                                    Ok(s) => s,
+                                    Err(_) => {
+                                        MantaObjectShark {
+                                            manta_storage_id: evac_payload
+                                                .from_shark.clone(),
+                                            datacenter: String::from
+                                                ("Somefakedc")
+                                        }
+                                    }
+                                };
+                                */
+
+                            let job_action = JobAction::Evacuate(
+                                Box::new(EvacuateJob::new(
+
+                                    shark,
+                                    &domain_name,
+                                    &job_uuid,
+                                    max_objects,
+                                )));
+
+                            job.add_action(job_action);
+                            self.tx.send(job).expect("Send job to threadpool");
+                            let res = create_response(
+                                &state,
+                                StatusCode::OK,
+                                mime::APPLICATION_JSON,
+                                job_uuid
+                            );
+                            future::ok((state, res))
+                        }
+                    }
+                },
+                Err(e) => future::err((state, e.into_handler_error())),
+            });
+        Box::new(f)
+    }
+}
 
 fn router() -> Router {
+    let (tx, rx) = crossbeam_channel::bounded(5);
+    let job_create_handler = JobCreateHandler {
+        tx
+    };
+
+    //job_thread_pool(rx);
+    let pool = ThreadPool::new(THREAD_COUNT);
+    for _ in 0..THREAD_COUNT {
+        let thread_rx = rx.clone();
+        pool.execute(move || loop {
+            let job = match thread_rx.recv() {
+                Ok(j) => j,
+                Err(_) => {
+                    // TODO Check error
+                    return;
+                }
+            };
+            job.run().expect("bad job run");
+        });
+    }
+
     build_simple_router(|route| {
         route.get("/jobs/:uuid")
             .with_path_extractor::<GetJobParams>()
@@ -90,12 +249,13 @@ fn router() -> Router {
         route.get("/jobs")
             .to(list_jobs);
         route.post("/jobs")
-            .to(create_job);
+            .to_new_handler(job_create_handler.clone());
     })
 }
 
 fn main() {
     let addr = "0.0.0.0:8888";
+
     gotham::start(addr, router())
 }
 
@@ -133,5 +293,41 @@ mod tests {
         let ret = response.read_body().unwrap();
         let pretty_response: JobStatus = serde_json::from_slice(&ret).unwrap();
         println!("{:#?}", pretty_response);
+    }
+
+    #[test]
+    fn post_test () {
+        let _guard = util::init_global_logger();
+        let test_server = TestServer::new(router()).unwrap();
+        let action_payload = EvacuateJobPayload {
+            domain_name: Some(String::from("fake.joyent.us")),
+            from_shark: String::from("fake_shark"),
+            max_objects: None,
+        };
+
+        let job_payload = JobPayload {
+            action: JobActionPayload::Evacuate(action_payload)
+        };
+
+        let payload = serde_json::to_string(&job_payload).unwrap();
+
+        println!("===========================");
+        println!("{}", payload);
+        println!("===========================");
+        let response = test_server
+            .client()
+            .post("http://localhost:8888/jobs", payload, mime::APPLICATION_JSON)
+            .perform()
+            .unwrap();
+
+        if response.status() != StatusCode::OK {
+            println!("CHECK ME");
+            return;
+        }
+        let ret = response.read_utf8_body().unwrap();
+        println!("{:#?}", ret);
+
+        //let pretty_response: String = serde_json::from_slice(&ret).unwrap();
+        //println!("{:#?}", pretty_response);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,23 +6,27 @@ extern crate serde_derive;
 
 use std::collections::HashMap;
 
-use remora::jobs::{self, JobAction};
 use remora::config;
+use remora::jobs::{self, JobAction};
 use remora::moray_client;
 use remora::util;
 
 use crossbeam_channel;
-use gotham::handler::{IntoResponse, NewHandler, Handler, HandlerFuture, IntoHandlerError};
+use futures::{future, Future, Stream};
+use gotham::handler::{
+    Handler, HandlerFuture, IntoHandlerError, IntoResponse, NewHandler,
+};
 use gotham::helpers::http::response::create_response;
+use gotham::router::builder::{
+    build_simple_router, DefineSingleRoute, DrawRoutes,
+};
 use gotham::router::Router;
-use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
-use gotham::state::{State, FromState};
+use gotham::state::{FromState, State};
 use hyper::{Body, Response, StatusCode};
-use uuid::Uuid;
-use threadpool::ThreadPool;
-use futures::{Stream, Future, future};
-use remora::jobs::evacuate::EvacuateJob;
 use libmanta::moray::MantaObjectShark;
+use remora::jobs::evacuate::EvacuateJob;
+use threadpool::ThreadPool;
+use uuid::Uuid;
 
 static THREAD_COUNT: usize = 1;
 
@@ -33,12 +37,12 @@ struct GetJobParams {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct JobStatus {
-    status: HashMap<String, usize>
+    status: HashMap<String, usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 struct JobList {
-    jobs: Vec<String>
+    jobs: Vec<String>,
 }
 
 impl IntoResponse for JobStatus {
@@ -47,8 +51,7 @@ impl IntoResponse for JobStatus {
             &state,
             StatusCode::OK,
             mime::APPLICATION_JSON,
-            serde_json::to_string(&self)
-                .expect("serialized Job Status")
+            serde_json::to_string(&self).expect("serialized Job Status"),
         )
     }
 }
@@ -69,15 +72,14 @@ impl IntoResponse for JobList {
             &state,
             StatusCode::OK,
             mime::APPLICATION_JSON,
-            serde_json::to_string(&self)
-                .expect("serialized Job Status")
+            serde_json::to_string(&self).expect("serialized Job Status"),
         )
     }
 }
 
 fn list_jobs(state: State) -> (State, JobList) {
     let response = JobList {
-        jobs: jobs::status::list_jobs().unwrap()
+        jobs: jobs::status::list_jobs().unwrap(),
     };
 
     (state, response)
@@ -103,7 +105,7 @@ struct JobPayload {
 
 #[derive(Serialize, Deserialize)]
 enum JobActionPayload {
-    Evacuate(EvacuateJobPayload)
+    Evacuate(EvacuateJobPayload),
 }
 
 impl Default for JobActionPayload {
@@ -121,20 +123,21 @@ struct EvacuateJobPayload {
 
 #[derive(Clone)]
 struct JobCreateHandler {
-    tx: crossbeam_channel::Sender<jobs::Job>
+    tx: crossbeam_channel::Sender<jobs::Job>,
 }
 
 impl NewHandler for JobCreateHandler {
     type Instance = Self;
 
-    fn new_handler(&self)  -> gotham::error::Result<Self::Instance> {
+    fn new_handler(&self) -> gotham::error::Result<Self::Instance> {
         Ok(self.clone())
     }
 }
 
+/*
 impl Handler for JobCreateHandler {
     fn handle(self, mut state: State) -> Box<HandlerFuture> {
-        // here rui
+        // TODO:  config parsing should be done when the process starts
         let config = config::Config::parse_config(None).expect("Config parse");
         let mut job = jobs::Job::new(config.clone());
         let job_uuid = job.get_id().to_string();
@@ -178,20 +181,10 @@ impl Handler for JobCreateHandler {
 
                             };
                             /*
-                                match moray_client::get_manta_object_shark (
+                            let shark moray_client::get_manta_object_shark (
                                 &evac_payload.from_shark,
-                                &domain_name) {
-                                    Ok(s) => s,
-                                    Err(_) => {
-                                        MantaObjectShark {
-                                            manta_storage_id: evac_payload
-                                                .from_shark.clone(),
-                                            datacenter: String::from
-                                                ("Somefakedc")
-                                        }
-                                    }
-                                };
-                                */
+                                &domain_name).expect("get shark");
+                            */
 
                             let job_action = JobAction::Evacuate(
                                 Box::new(EvacuateJob::new(
@@ -219,12 +212,88 @@ impl Handler for JobCreateHandler {
         Box::new(f)
     }
 }
+*/
+
+impl Handler for JobCreateHandler {
+    fn handle(self, mut state: State) -> Box<HandlerFuture> {
+        // TODO:  config parsing should be done when the process starts
+        let config = config::Config::parse_config(None).expect("Config parse");
+        let mut job = jobs::Job::new(config.clone());
+        let job_uuid = job.get_id().to_string();
+
+        let f =
+            Body::take_from(&mut state).concat2().then(
+                move |body| match body {
+                    Ok(valid_body) => {
+                        let payload: JobPayload =
+                            serde_json::from_slice(&valid_body.into_bytes())
+                                .expect("Bad Payload");
+                        future::ok(payload)
+                    }
+                    Err(e) => future::err(e.into_handler_error()),
+                },
+            );
+
+        let payload = f.wait().expect("Bad payload");
+        let ret = match payload.action {
+            JobActionPayload::Evacuate(evac_payload) => {
+                let domain_name = evac_payload
+                    .domain_name
+                    .unwrap_or(config.domain_name.clone());
+                let max_objects = match evac_payload.max_objects {
+                    Some(str_val) => {
+                        // TODO
+                        let val: u32 = str_val.parse().expect("max obj parse");
+
+                        if val == 0 {
+                            None
+                        } else {
+                            Some(val)
+                        }
+                    }
+                    None => {
+                        Some(10) // Default
+                    }
+                };
+
+                // TODO: We are temporarily faking a shark for
+                // testing
+                let shark = MantaObjectShark {
+                    manta_storage_id: evac_payload.from_shark.clone(),
+                    datacenter: String::from("Somefakedc"),
+                };
+                /*
+                let shark moray_client::get_manta_object_shark (
+                    &evac_payload.from_shark,
+                    &domain_name).expect("get shark");
+                */
+
+                let job_action =
+                    JobAction::Evacuate(Box::new(EvacuateJob::new(
+                        shark,
+                        &domain_name,
+                        &job_uuid,
+                        max_objects,
+                    )));
+
+                job.add_action(job_action);
+                self.tx.send(job).expect("Send job to threadpool");
+                create_response(
+                    &state,
+                    StatusCode::OK,
+                    mime::APPLICATION_JSON,
+                    job_uuid,
+                )
+            }
+        };
+
+        Box::new(future::ok((state, ret)))
+    }
+}
 
 fn router() -> Router {
     let (tx, rx) = crossbeam_channel::bounded(5);
-    let job_create_handler = JobCreateHandler {
-        tx
-    };
+    let job_create_handler = JobCreateHandler { tx };
 
     //job_thread_pool(rx);
     let pool = ThreadPool::new(THREAD_COUNT);
@@ -243,12 +312,13 @@ fn router() -> Router {
     }
 
     build_simple_router(|route| {
-        route.get("/jobs/:uuid")
+        route
+            .get("/jobs/:uuid")
             .with_path_extractor::<GetJobParams>()
             .to(get_job);
-        route.get("/jobs")
-            .to(list_jobs);
-        route.post("/jobs")
+        route.get("/jobs").to(list_jobs);
+        route
+            .post("/jobs")
             .to_new_handler(job_create_handler.clone());
     })
 }
@@ -280,15 +350,10 @@ mod tests {
         println!("{:#?}", job_list);
 
         let get_this_job = job_list.jobs[0].clone();
-        let get_job_uri = format!("http://localhost:8888/jobs/{}",
-                                  get_this_job);
+        let get_job_uri =
+            format!("http://localhost:8888/jobs/{}", get_this_job);
 
-        let response = test_server
-            .client()
-            .get(get_job_uri)
-            .perform()
-            .unwrap();
-
+        let response = test_server.client().get(get_job_uri).perform().unwrap();
 
         let ret = response.read_body().unwrap();
         let pretty_response: JobStatus = serde_json::from_slice(&ret).unwrap();
@@ -296,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    fn post_test () {
+    fn post_test() {
         let _guard = util::init_global_logger();
         let test_server = TestServer::new(router()).unwrap();
         let action_payload = EvacuateJobPayload {
@@ -306,7 +371,7 @@ mod tests {
         };
 
         let job_payload = JobPayload {
-            action: JobActionPayload::Evacuate(action_payload)
+            action: JobActionPayload::Evacuate(action_payload),
         };
 
         let payload = serde_json::to_string(&job_payload).unwrap();
@@ -316,7 +381,11 @@ mod tests {
         println!("===========================");
         let response = test_server
             .client()
-            .post("http://localhost:8888/jobs", payload, mime::APPLICATION_JSON)
+            .post(
+                "http://localhost:8888/jobs",
+                payload,
+                mime::APPLICATION_JSON,
+            )
             .perform()
             .unwrap();
 


### PR DESCRIPTION
This is an initial whack at a REST API.  It assumes we have the job_status work as it exposes endpoints to get status.