### PR TITLE
MANTA-4871 rebalancer should provide job status as part of job list command / endpoint

### DIFF
--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -259,7 +259,7 @@ fn job_create_subcommand_handler(
         moray_client::get_manta_object_shark(&shark_id, &domain_name)
             .map_err(Error::from)?;
 
-    let mut job = Job::new(config);
+    let mut job = Job::new(config)?;
     let job_action = JobAction::Evacuate(Box::new(EvacuateJob::new(
         from_shark,
         &domain_name,

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -15,8 +15,8 @@ use serde::Deserialize;
 use std::fs::File;
 use std::io::BufReader;
 
+use crate::jobs::{Job, JobBuilder};
 use crate::moray_client;
-use crate::jobs::{evacuate::EvacuateJob, Job, JobAction, JobBuilder};
 use rebalancer::error::Error;
 use rebalancer::util;
 use uuid::Uuid;

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -15,8 +15,8 @@ use serde::Deserialize;
 use std::fs::File;
 use std::io::BufReader;
 
-use crate::jobs::{evacuate::EvacuateJob, Job, JobAction};
 use crate::moray_client;
+use crate::jobs::{evacuate::EvacuateJob, Job, JobAction, JobBuilder};
 use rebalancer::error::Error;
 use rebalancer::util;
 use uuid::Uuid;
@@ -259,14 +259,9 @@ fn job_create_subcommand_handler(
         moray_client::get_manta_object_shark(&shark_id, &domain_name)
             .map_err(Error::from)?;
 
-    let mut job = Job::new(config)?;
-    let job_action = JobAction::Evacuate(Box::new(EvacuateJob::new(
-        from_shark,
-        &domain_name,
-        &job.get_id().to_string(),
-        max_objects,
-    )));
-    job.add_action(job_action);
+    let job = JobBuilder::new(config)
+        .evacuate(from_shark, &domain_name, max_objects)
+        .commit()?;
 
     Ok(SubCommand::DoJob(Box::new(job)))
 }

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -1517,7 +1517,20 @@ fn start_sharkspotter(
                         std::io::Error::new(ErrorKind::Other, e.description())
                     })
             })
-            .map_err(Error::from)
+            .map_err(|e| {
+                if e.kind() == ErrorKind::Interrupted {
+                    if let Some(max) = max_objects {
+                        if count > max {
+                            return InternalError::new(
+                                Some(InternalErrorCode::MaxObjectsLimit),
+                                "Max Objects Limit Reached",
+                            )
+                            .into();
+                        }
+                    }
+                }
+                e.into()
+            })
         })
         .map_err(Error::from)
 }

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -1671,8 +1671,11 @@ where
             while !done {
                 // TODO: MANTA-4519
                 // get a fresh shark list
-                let mut shark_list =
-                    job_action.get_shark_list(Arc::clone(&storinfo), &algo, 3)?;
+                let mut shark_list = job_action.get_shark_list(
+                    Arc::clone(&storinfo),
+                    &algo,
+                    3,
+                )?;
 
                 // TODO: file ticket, tunable number of sharks which implies
                 // number of threads.

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -454,6 +454,8 @@ impl EvacuateJob {
         // depending on how we implement job restarts we may want to move it out.
         self.create_table()?;
 
+        let mut ret = Ok(());
+
         // job_action will be shared between threads so create an Arc for it.
         let job_action = Arc::new(self);
 
@@ -522,6 +524,7 @@ impl EvacuateJob {
                             "Encountered empty storinfo on startup, exiting \
                              safely"
                         );
+                        set_run_error(&mut ret, err);
                     } else {
                         panic!("Error {}", err);
                     }
@@ -537,25 +540,35 @@ impl EvacuateJob {
             .join()
             .expect("Sharkspotter Thread")
             .unwrap_or_else(|e| {
-                error!("Error joining sharkspotter handle: {}\n", e);
+                error!("Error joining sharkspotter: {}\n", e);
+                set_run_error(&mut ret, e);
             });
 
         post_thread
             .join()
             .expect("Post Thread")
-            .expect("Error joining assignment processor thread");
+            .unwrap_or_else(|e| {
+                error!("Error joining post thread: {}\n", e);
+                set_run_error(&mut ret, e);
+            });
 
         assignment_checker_thread
             .join()
             .expect("Checker Thread")
-            .expect("Error joining assignment checker thread");
+            .unwrap_or_else(|e| {
+                error!("Error joining assignment checker thread: {}\n", e);
+                set_run_error(&mut ret, e);
+            });
 
         metadata_update_thread
             .join()
             .expect("MD Update Thread")
-            .expect("Error joining metadata update thread");
+            .unwrap_or_else(|e| {
+                error!("Error joining metadata update thread: {}\n", e);
+                set_run_error(&mut ret, e);
+            });
 
-        Ok(())
+        ret
     }
 
     fn set_assignment_state(
@@ -2663,6 +2676,21 @@ fn start_metadata_update_broker(
             Ok(())
         })
         .map_err(Error::from)
+}
+
+// In the future we may want to return a vector of errors.  But since our
+// architecture is such that all the various threads are connected by
+// channels, an error in one channel cascades to other channels.  So, it is
+// most likely the case that the first error is the most (and only) valuable
+// one to the user.  At any rate, all errors are still logged, but the job
+// error is only for the job DB.
+fn set_run_error<E>(current_error: &mut Result<(), Error>, err: E)
+where
+    E: Into<Error>,
+{
+    if current_error.is_ok() {
+        *current_error = Err(err.into());
+    }
 }
 
 #[cfg(test)]

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -1412,7 +1412,7 @@ fn start_sharkspotter(
                 if let Some(max) = max_objects {
                     if count > max {
                         return Err(std::io::Error::new(
-                            ErrorKind::Other,
+                            ErrorKind::Interrupted,
                             "Max Objects Limit Reached",
                         ));
                     }

--- a/manager/src/jobs/mod.rs
+++ b/manager/src/jobs/mod.rs
@@ -84,6 +84,8 @@ pub enum JobState {
     Failed,
 }
 
+// This exact impl occurs for at least 2 other enums.  We should consider
+// making this a custom derive
 impl ToSql<sql_types::Text, Pg> for JobState {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
         let action = self.to_string();

--- a/manager/src/jobs/mod.rs
+++ b/manager/src/jobs/mod.rs
@@ -12,9 +12,8 @@ pub mod evacuate;
 pub mod status;
 
 use crate::config::Config;
-use crate::storinfo::StorageNode;
 use crate::pg_db::connect_or_create_db;
-use crate::picker::StorageNode;
+use crate::storinfo::StorageNode;
 use rebalancer::common::{ObjectId, Task};
 use rebalancer::error::{Error, InternalError, InternalErrorCode};
 

--- a/manager/src/jobs/mod.rs
+++ b/manager/src/jobs/mod.rs
@@ -39,7 +39,7 @@ pub type StorageId = String; // Hostname
 pub type AssignmentId = String; // UUID
 pub type HttpStatusCode = u16;
 
-static REBALANCER_DB: &str = "rebalancer";
+pub(crate) static REBALANCER_DB: &str = "rebalancer";
 
 pub struct Job {
     id: Uuid,
@@ -118,13 +118,20 @@ impl JobBuilder {
 // developers recommend.
 // https://github.com/diesel-rs/diesel/issues/860
 #[derive(
-    Insertable, Queryable, Identifiable, AsChangeset, AsExpression, PartialEq,
+    Debug,
+    Insertable,
+    Queryable,
+    Identifiable,
+    AsChangeset,
+    AsExpression,
+    PartialEq,
+    Serialize,
 )]
 #[table_name = "jobs"]
-struct JobDbEntry {
-    id: String,
-    action: JobActionDbEntry,
-    state: JobState,
+pub struct JobDbEntry {
+    pub id: String,
+    pub action: JobActionDbEntry,
+    pub state: JobState,
 }
 
 table! {
@@ -141,7 +148,14 @@ table! {
 //#[sql_type = "sql_types::Text"]
 #[sql_type = "sql_types::Text"]
 #[derive(
-    Debug, Display, Clone, EnumString, FromSqlRow, AsExpression, PartialEq,
+    Serialize,
+    Debug,
+    Display,
+    Clone,
+    EnumString,
+    FromSqlRow,
+    AsExpression,
+    PartialEq,
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum JobState {
@@ -186,9 +200,11 @@ impl JobAction {
 }
 
 #[sql_type = "sql_types::Text"]
-#[derive(Debug, Display, EnumString, FromSqlRow, AsExpression, PartialEq)]
+#[derive(
+    Serialize, Debug, Display, EnumString, FromSqlRow, AsExpression, PartialEq,
+)]
 #[strum(serialize_all = "snake_case")]
-enum JobActionDbEntry {
+pub enum JobActionDbEntry {
     Evacuate,
     None,
 }

--- a/manager/src/jobs/mod.rs
+++ b/manager/src/jobs/mod.rs
@@ -28,7 +28,6 @@ use diesel::sql_types;
 use evacuate::EvacuateJob;
 use libmanta::moray::MantaObjectShark;
 use serde::{Deserialize, Serialize};
-use std::io::ErrorKind;
 use std::io::Write;
 use std::str::FromStr;
 
@@ -330,8 +329,8 @@ impl Job {
                         // This dance is only intended to support the
                         // evacuate object limit which will eventually be
                         // removed.
-                        Error::IoError(err) => match err.kind() {
-                            ErrorKind::Interrupted => {
+                        Error::Internal(err) => match err.code {
+                            InternalErrorCode::MaxObjectsLimit => {
                                 info!("Job {} complete", self.id);
                                 Ok(())
                             }

--- a/manager/src/jobs/status.rs
+++ b/manager/src/jobs/status.rs
@@ -10,8 +10,8 @@
 
 use super::evacuate::EvacuateObjectStatus;
 
+use crate::jobs::{JobDbEntry, REBALANCER_DB};
 use crate::pg_db;
-use manager::jobs::{JobDbEntry, REBALANCER_DB};
 use rebalancer::error::Error;
 
 use std::collections::HashMap;

--- a/manager/src/jobs/status.rs
+++ b/manager/src/jobs/status.rs
@@ -80,7 +80,7 @@ pub fn list_jobs() -> Result<Vec<JobDbEntry>, StatusError> {
         Ok(conn) => conn,
         Err(e) => {
             error!("Error connecting to rebalancer DB: {}", e);
-            return Err(StatusError::DBExists);
+            return Err(StatusError::Unknown);
         }
     };
 

--- a/manager/src/jobs/status.rs
+++ b/manager/src/jobs/status.rs
@@ -9,11 +9,12 @@
  */
 
 use super::evacuate::EvacuateObjectStatus;
+
 use crate::pg_db;
+use manager::jobs::{JobDbEntry, REBALANCER_DB};
 use rebalancer::error::Error;
 
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::string::ToString;
 
 use diesel::prelude::*;
@@ -72,23 +73,26 @@ pub fn get_status(uuid: Uuid) -> Result<HashMap<String, usize>, StatusError> {
     Ok(ret)
 }
 
-pub fn list_jobs() -> Result<Vec<String>, StatusError> {
-    let db_list = match pg_db::list_databases() {
+pub fn list_jobs() -> Result<Vec<JobDbEntry>, StatusError> {
+    use crate::jobs::jobs::dsl::jobs as jobs_db;
+
+    let conn = match pg_db::connect_or_create_db(REBALANCER_DB) {
+        Ok(conn) => conn,
+        Err(e) => {
+            error!("Error connecting to rebalancer DB: {}", e);
+            return Err(StatusError::DBExists);
+        }
+    };
+
+    let job_list = match jobs_db.load::<JobDbEntry>(&conn) {
         Ok(list) => list,
         Err(e) => {
             error!("Error listing jobs: {}", e);
             return Err(StatusError::Unknown);
         }
     };
-    let mut ret = vec![];
 
-    for db in db_list {
-        if let Ok(job_id) = Uuid::from_str(&db) {
-            ret.push(job_id.to_string());
-        }
-    }
-
-    Ok(ret)
+    Ok(job_list)
 }
 
 #[cfg(test)]

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -18,8 +18,7 @@ extern crate serde_derive;
 extern crate rebalancer;
 
 use manager::config::{self, Config};
-use manager::jobs::{self, JobAction, JobBuilder, JobDbEntry};
-use manager::jobs::evacuate::EvacuateJob;
+use manager::jobs::{self, JobBuilder, JobDbEntry};
 use manager::jobs::status::StatusError;
 use std::collections::HashMap;
 use std::string::ToString;
@@ -372,7 +371,7 @@ fn main() {
         .unwrap();
 
     if let Err(e) = jobs::create_job_database() {
-        remora::error!("Error creating Jobs database: {}", e);
+        error!("Error creating Jobs database: {}", e);
         return;
     }
 

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -18,7 +18,7 @@ extern crate serde_derive;
 extern crate rebalancer;
 
 use manager::config::{self, Config};
-use manager::jobs::{self, JobAction, JobBuilder};
+use manager::jobs::{self, JobAction, JobBuilder, JobDbEntry};
 use manager::jobs::evacuate::EvacuateJob;
 use manager::jobs::status::StatusError;
 use std::collections::HashMap;
@@ -146,7 +146,7 @@ fn get_job(mut state: State) -> Box<HandlerFuture> {
 }
 
 type JobListFuture =
-    Box<dyn Future<Item = Vec<String>, Error = StatusError> + Send>;
+    Box<dyn Future<Item = Vec<JobDbEntry>, Error = StatusError> + Send>;
 
 fn get_job_list() -> JobListFuture {
     Box::new(match jobs::status::list_jobs() {

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -18,10 +18,9 @@ extern crate serde_derive;
 extern crate rebalancer;
 
 use manager::config::{self, Config};
-use manager::jobs::{self, JobBuilder, JobDbEntry};
 use manager::jobs::status::StatusError;
+use manager::jobs::{self, JobBuilder, JobDbEntry};
 use std::collections::HashMap;
-use std::string::ToString;
 use std::error::Error;
 
 use rebalancer::util;

--- a/manager/src/pg_db.rs
+++ b/manager/src/pg_db.rs
@@ -57,6 +57,9 @@ pub fn create_and_connect_db(db_name: &str) -> Result<PgConnection, Error> {
     connect_db(db_name)
 }
 
+// Try to connect to the specified database, if not, create the database and
+// connect to it.  In either case, on success, return the PgConnection, and
+// Error on failure.
 pub fn connect_or_create_db(db_name: &str) -> Result<PgConnection, Error> {
     match connect_db(db_name) {
         Ok(conn) => Ok(conn),

--- a/manager/src/pg_db.rs
+++ b/manager/src/pg_db.rs
@@ -12,8 +12,8 @@ use rebalancer::error::Error;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::sql_query;
 use diesel::result::ConnectionError;
+use diesel::sql_query;
 
 static DB_URL: &str = "postgres://postgres:postgres@";
 
@@ -73,5 +73,3 @@ pub fn connect_or_create_db(db_name: &str) -> Result<PgConnection, Error> {
         }
     }
 }
-
-

--- a/manager/src/rebalancer-adm.rs
+++ b/manager/src/rebalancer-adm.rs
@@ -49,8 +49,22 @@ fn main() -> Result<(), Error> {
         },
         SubCommand::JobList => match status::list_jobs() {
             Ok(list) => {
+                let width = 20;
+                println!(
+                    "{:<width$}{:<width$}{:<width$}",
+                    "JOB",
+                    "ACTION",
+                    "STATE",
+                    width = width
+                );
                 for job in list {
-                    println!("{}", job);
+                    println!(
+                        "{:<width$}{:<width$}{:<width$}",
+                        job.id,
+                        job.action,
+                        job.state,
+                        width = width,
+                    );
                 }
                 Ok(())
             }

--- a/manager/src/storinfo.rs
+++ b/manager/src/storinfo.rs
@@ -118,6 +118,7 @@ impl Storinfo {
     /// Populate the storinfo's sharks field, and start the storinfo updater thread.
     pub fn start(&mut self) -> Result<(), Error> {
         let mut locked_sharks = self.sharks.lock().unwrap();
+        // TODO: MANTA-4961, don't start job if picker cannot be reached.
         *locked_sharks = Some(fetch_sharks(&self.host));
 
         let handle = Self::updater(

--- a/rebalancer/src/error.rs
+++ b/rebalancer/src/error.rs
@@ -24,6 +24,15 @@ pub enum Error {
     DieselConnection(diesel::ConnectionError),
 }
 
+impl Error {
+    pub fn to_internal_error(&self) -> Option<InternalError> {
+        match self {
+            Error::Internal(e) => Some(e.to_owned()),
+            _ => None
+        }
+    }
+}
+
 impl std::error::Error for Error {
     fn description(&self) -> &str {
         match self {
@@ -122,7 +131,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct InternalError {
     msg: String,
     pub code: InternalErrorCode,
@@ -140,6 +149,8 @@ pub enum InternalErrorCode {
     HashNotFound,
     DuplicateShark,
     BadMantaObject,
+    JobBuilderError,
+    MaxObjectsLimit,
 }
 
 impl fmt::Display for InternalError {
@@ -203,3 +214,4 @@ impl<T> fmt::Display for CrossbeamError<T> {
         }
     }
 }
+

--- a/rebalancer/src/error.rs
+++ b/rebalancer/src/error.rs
@@ -24,15 +24,6 @@ pub enum Error {
     DieselConnection(diesel::ConnectionError),
 }
 
-impl Error {
-    pub fn to_internal_error(&self) -> Option<InternalError> {
-        match self {
-            Error::Internal(e) => Some(e.to_owned()),
-            _ => None,
-        }
-    }
-}
-
 impl std::error::Error for Error {
     fn description(&self) -> &str {
         match self {

--- a/rebalancer/src/error.rs
+++ b/rebalancer/src/error.rs
@@ -28,7 +28,7 @@ impl Error {
     pub fn to_internal_error(&self) -> Option<InternalError> {
         match self {
             Error::Internal(e) => Some(e.to_owned()),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -214,4 +214,3 @@ impl<T> fmt::Display for CrossbeamError<T> {
         }
     }
 }
-


### PR DESCRIPTION
Rebalancer list jobs endpoint now returns job action and state along with uuid.

```
curl -s http://localhost:8888/jobs/ | /usr/bin/json
[
  {
    "id": "50003e9f-80fd-4515-8f30-c4a897992c09",
    "action": "Evacuate",
    "state": "Complete"
  },
  {
    "id": "f721bb81-f6c6-47ca-8a78-853dec3aae41",
    "action": "Evacuate",
    "state": "Complete"
  },
  {
    "id": "518aa4dd-6a51-4908-89a8-2df8437fcb0f",
    "action": "Evacuate",
    "state": "Complete"
  },
  {
    "id": "b373e20c-bed8-4b07-8de5-f6505b7ee6f9",
    "action": "Evacuate",
    "state": "Complete"
  },
  {
    "id": "4bd81972-4390-44a6-bde0-996ee7e40d08",
    "action": "Evacuate",
    "state": "Complete"
  }
]
```