### PR TITLE
MANTA-4836 rebalancer should allow partial manta_storage_id in job payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,6 +1022,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rebalancer 0.1.0",
  "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "resolve 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1032,7 +1033,6 @@ dependencies = [
  "strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trust-dns-resolver 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1457,6 +1457,15 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1733,6 +1742,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "resolve"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2802,6 +2822,7 @@ dependencies = [
 "checksum quickcheck_helpers 0.1.0 (git+https://github.com/joyent/rust-quickcheck-helpers.git?tag=v0.1.0)" = "<none>"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -2826,6 +2847,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
+"checksum resolve 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "19526b305899bea65f26edda78a64f5313958494321ee0ab66bd94b32958614a"
 "checksum rusqlite 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ebca2e7e3deb7241b7fa5929c088548c590728b1b740c479594c23f813eb8a7"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rust_fast 0.1.0 (git+https://github.com/joyent/rust-fast?tag=v0.1.0)" = "<none>"

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ clippy-deps:
 	rustup component add clippy
 
 jobtests:
+	RUST_LOG=remora=trace $(CARGO) test tests --bin rebalancer-manager -- --test-threads=1
 	RUST_LOG=remora=trace $(CARGO) test job -- --test-threads=1
 
 agenttests:

--- a/manager/Cargo.toml
+++ b/manager/Cargo.toml
@@ -35,7 +35,7 @@ slog = "2.5.2"
 slog-bunyan = { git = "https://github.com/slog-rs/bunyan" }
 slog-scope = "4.1.2"
 threadpool = "1.7.1"
-trust-dns-resolver = "0.11.1"
+resolve = "0.2.0"
 
 [[bin]]
 name = "rebalancer-manager"

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -16,7 +16,6 @@ use std::fs::File;
 use std::io::BufReader;
 
 use crate::jobs::{Job, JobBuilder};
-use crate::moray_client;
 use rebalancer::error::Error;
 use rebalancer::util;
 use uuid::Uuid;
@@ -255,12 +254,8 @@ fn job_create_subcommand_handler(
 
     let max_objects = if max == 0 { None } else { Some(max) };
     let shark_id = format!("{}.{}", shark_id, domain_name);
-    let from_shark =
-        moray_client::get_manta_object_shark(&shark_id, &domain_name)
-            .map_err(Error::from)?;
-
     let job = JobBuilder::new(config)
-        .evacuate(from_shark, &domain_name, max_objects)
+        .evacuate(shark_id, &domain_name, max_objects)
         .commit()?;
 
     Ok(SubCommand::DoJob(Box::new(job)))

--- a/manager/src/moray_client.rs
+++ b/manager/src/moray_client.rs
@@ -16,52 +16,112 @@ use moray::{
 use rebalancer::error::{Error, InternalError, InternalErrorCode};
 use serde_json::Value;
 use slog_scope;
-use std::net::IpAddr;
-use trust_dns_resolver::Resolver;
+use std::net::{IpAddr, SocketAddr};
 
 static MANTA_BUCKET: &str = "manta";
 static MANTA_STORAGE_BUCKET: &str = "manta_storage";
+static MANTA_STORAGE_BUCKET_SHARD: u32 = 1;
 static MANTA_STORAGE_ID: &str = "manta_storage_id";
 
-fn lookup_ip(host: &str) -> Result<IpAddr, Error> {
-    let resolver = Resolver::from_system_conf()?;
-    let response = resolver.lookup_ip(host)?;
-    let ip: Vec<IpAddr> = response.iter().collect();
+// We can't use trust-dns-resolver here because it uses futures with a
+// block_on, and calling a block_on from within a block_on is not allowed.
+use resolve::resolve_host;
+use resolve::{record::Srv, DnsConfig, DnsResolver};
 
-    Ok(ip[0])
+// Get the SRV record which gives us the target and port of the moray service.
+fn get_srv_record(svc: &str, proto: &str, host: &str) -> Result<Srv, Error> {
+    let query = format!("{}.{}.{}", svc, proto, host);
+    let r = DnsResolver::new(DnsConfig::load_default()?)?;
+    match r.resolve_record::<Srv>(&query)?.first() {
+        Some(rec) => {
+            dbg!(&rec);
+            Ok(rec.clone())
+        }
+        None => Err(InternalError::new(
+            Some(InternalErrorCode::IpLookupError),
+            "SRV Lookup returned success with 0 IPs",
+        )
+        .into()),
+    }
 }
 
+fn lookup_ip(host: &str) -> Result<IpAddr, Error> {
+    match resolve_host(host)?.collect::<Vec<IpAddr>>().first() {
+        Some(a) => Ok(*a),
+        None => Err(InternalError::new(
+            Some(InternalErrorCode::IpLookupError),
+            "IP Lookup returned success with 0 IPs",
+        )
+        .into()),
+    }
+}
+
+fn get_moray_srv_sockaddr(host: &str) -> Result<SocketAddr, Error> {
+    let srv_record = get_srv_record("_moray", "_tcp", &host)?;
+    dbg!(&srv_record);
+
+    let ip = lookup_ip(&srv_record.target)?;
+
+    Ok(SocketAddr::new(ip, srv_record.port))
+}
+
+// Create a moray client using the shard and the domain name only.  This will
+// query binder for the SRV record for us.
 pub fn create_client(shard: u32, domain: &str) -> Result<MorayClient, Error> {
     let domain_name = format!("{}.moray.{}", shard, domain);
+    debug!("Creating moray client for: {}", domain_name);
 
-    info!("Creating moray client for: {}", domain_name);
+    let sock_addr = get_moray_srv_sockaddr(&domain_name)?;
+    trace!("Found SockAddr for moray: {:#?}", &sock_addr);
 
-    // TODO: Lookup SRV record for port number
-    // Waiting on trust-dns-resolver issue:
-    // https://github.com/bluejekyll/trust-dns/issues/872
-    let ip = lookup_ip(&domain_name)?;
-    MorayClient::from_parts(ip, 2021, slog_scope::logger(), None)
-        .map_err(Error::from)
+    MorayClient::new(sock_addr, slog_scope::logger(), None).map_err(Error::from)
 }
 
+// Create a moray client, and then lookup the MantaObjectShard entry from the
+// storage id.
 pub fn get_manta_object_shark(
     storage_id: &str,
     domain: &str,
 ) -> Result<MantaObjectShark, Error> {
-    let mut mclient = create_client(1, domain)?;
-    let filter = format!("{}={}", MANTA_STORAGE_ID, storage_id);
+    let mut mclient = create_client(MANTA_STORAGE_BUCKET_SHARD, domain)?;
+    let mut ret: Option<MantaObjectShark> = None;
+    let mut shark_id = storage_id.to_string();
     let opts = ObjectMethodOptions::default();
-    let mut ret = MantaObjectShark::default();
+
+    if !storage_id.contains(domain) {
+        shark_id = format!("{}.{}", storage_id, domain);
+        warn!(
+            "Domain \"{}\" not found in storage_id:\"{}\", using \"{}\"",
+            domain, storage_id, shark_id
+        );
+    }
+
+    let filter = format!("{}={}", MANTA_STORAGE_ID, shark_id);
 
     mclient.find_objects(MANTA_STORAGE_BUCKET, &filter, &opts, |o| {
-        ret.manta_storage_id =
+        let manta_storage_id: String =
             serde_json::from_value(o.value[MANTA_STORAGE_ID].clone())?;
-        ret.datacenter = serde_json::from_value(o.value["datacenter"].clone())?;
+        let datacenter = serde_json::from_value(o.value["datacenter"].clone())?;
+        ret = Some(MantaObjectShark {
+            manta_storage_id,
+            datacenter,
+        });
         Ok(())
     })?;
 
-    Ok(ret)
+    match ret {
+        Some(mos) => Ok(mos),
+        None => {
+            let msg = format!("Error: Could not find shark {}", storage_id);
+            error!("{}", &msg);
+            Err(Error::from(InternalError::new(
+                Some(InternalErrorCode::SharkNotFound),
+                msg,
+            )))
+        }
+    }
 }
+
 pub fn put_object(
     mclient: &mut MorayClient,
     object: &Value,


### PR DESCRIPTION
Jira Issues Included:
```
MANTA-4836 rebalancer should allow partial manta_storage_id in job payload
MANTA-4984 rebalancer should lookup moray SRV record
MANTA-5025 simplify rebalancer job create payload
```

This wad does a few different things around simplifying the client interface.  

1. Now allow partial manta_storage_ids (e.g. `1.stor`) and assume the domain name as the one configured in the server.
2. Use the SRV record in the nameservice to find the port number for the moray service instead of having it hard coded.
3. New JobBuilder pattern allows us to create a job without blocking on external I/O.  See next bullet for impact there.
4. We verify the storage_id by looking it up in the shard 1 moray at job run time (not create time).  This allows the REST API to return a Job ID that the client can later use to look up the job status, without blocking on the call to the shard 1 moray.
5. Changed the Job Create payload to be more user friendly.