### PR TITLE
MANTA-5016 need node module for accessing manta storinfo service

### DIFF
--- a/manager/src/storinfo.rs
+++ b/manager/src/storinfo.rs
@@ -189,7 +189,7 @@ fn fetch_sharks(host: &str) -> Vec<StorageNode> {
     let mut new_sharks = vec![];
     let mut done = false;
     let mut after_id = String::new();
-    let base_url = format!("http://{}/poll", host);
+    let base_url = format!("http://{}/storagenodes", host);
     let limit = 100;
 
     while !done {


### PR DESCRIPTION
I'm about to push a change to manta-storinfo that makes the following changes to the Storinfo API:

- Rename GetSharks method to GetStorageNodes
- Change route from /poll to /storagenodes
- remove "only_id" param from /storagenodes
- Implement a new GetStorageNode (singular) method that allows retrieving a single storage node   record using manta storage id.
- New method has route: /storagenodes/:storageid

The behavior of the APIs wrt to the rebalancer manager is minimal - just a change to the route from /poll to /storagenodes.   Thuis one-line change addresses that.
