### PR TITLE
MANTA-5086 rename rebalancer-manager to rebalancer (smf and log upload names)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .idea/*
 cscope.*
 *.db
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ENGBLD_REQUIRE       := $(shell git submodule update --init deps/eng)
 include ./deps/eng/tools/mk/Makefile.defs
 TOP ?= $(error Unable to access eng.git submodule Makefiles.)
 
-SMF_MANIFESTS =     smf/manifests/rebalancer-manager.xml \
+SMF_MANIFESTS =     smf/manifests/rebalancer.xml \
                     smf/manifests/rebalancer-agent.xml
 
 AGENT_TARBALL       := $(NAME)-agent-$(STAMP).tar.gz
@@ -69,7 +69,7 @@ release: all deps/manta-scripts/.git $(SMF_MANIFESTS)
 	    target/release/rebalancer-adm \
 	    $(RELSTAGEDIR)/root/opt/smartdc/$(NAME)/bin/
 	cp -R \
-	    $(TOP)/smf/manifests/rebalancer-manager.xml \
+	    $(TOP)/smf/manifests/rebalancer.xml \
 	    $(RELSTAGEDIR)/root/opt/smartdc/$(NAME)/smf/manifests/
 	# boot
 	@mkdir -p $(RELSTAGEDIR)/root/opt/smartdc/boot/scripts

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -21,14 +21,14 @@ source /opt/smartdc/boot/scripts/services.sh
 
 manta_common_presetup
 manta_add_manifest_dir "/opt/smartdc/rebalancer"
-manta_common2_setup "rebalancer-manager"
+manta_common2_setup "rebalancer"
 
-echo "Setting up rebalancer-manager"
+echo "Setting up rebalancer manager"
 /usr/sbin/svccfg import /opt/local/lib/svc/manifest/postgresql.xml
 /usr/sbin/svcadm enable svc:/pkgsrc/postgresql:default
-/usr/sbin/svccfg import /opt/smartdc/rebalancer/smf/manifests/rebalancer-manager.xml
+/usr/sbin/svccfg import /opt/smartdc/rebalancer/smf/manifests/rebalancer.xml
 
-manta_common2_setup_log_rotation "rebalancer-manager"
+manta_common2_setup_log_rotation "rebalancer"
 manta_common2_setup_end
 
 exit 0

--- a/boot/setup.sh
+++ b/boot/setup.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 export PS4='[\D{%FT%TZ}] ${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'

--- a/sapi_manifests/rebalancer/manifest.json
+++ b/sapi_manifests/rebalancer/manifest.json
@@ -2,5 +2,5 @@
     "name": "rebalancer",
     "path": "/var/tmp/config.json",
     "master": true,
-    "post_cmd": "/usr/sbin/svcadm refresh rebalancer-manager"
+    "post_cmd": "/usr/sbin/svcadm refresh rebalancer"
 }

--- a/smf/manifests/rebalancer.xml
+++ b/smf/manifests/rebalancer.xml
@@ -10,8 +10,8 @@
     Copyright 2020 Joyent, Inc.
 -->
 
-<service_bundle type="manifest" name="rebalancer-manager">
-    <service name="manta/application/rebalancer-manager" type="service" version="1">
+<service_bundle type="manifest" name="rebalancer">
+    <service name="manta/application/rebalancer" type="service" version="1">
 
         <dependency name="network" grouping="require_all" restart_on="error" type="service">
             <service_fmri value="svc:/network/physical" />


### PR DESCRIPTION
This renames the SMF service name and log upload name to "rebalancer".
However, the *binary* name is still called "rebalancer-manager".