### PR TITLE
MANTA-5160 rebalancer should allow for static number of threads and a bounded queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +919,25 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "joyent-rust-utils"
 version = "0.1.0"
 source = "git+https://github.com/joyent/rust-utils?tag=v0.2.0#f8fc559c2abe98790ab16760cc97c185295103aa"
@@ -1018,6 +1042,7 @@ dependencies = [
  "gotham 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gotham_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "libmanta 0.7.0 (git+https://github.com/joyent/rust-libmanta?tag=v0.7.0)",
@@ -2900,6 +2925,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -2928,6 +2954,8 @@ dependencies = [
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+"checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 "checksum joyent-rust-utils 0.1.0 (git+https://github.com/joyent/rust-utils?tag=v0.2.0)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.3 (git+https://github.com/diesel-rs/diesel?rev=f75e930e166eb448e3c41d5cdc7251cfcad681f6)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "gotham 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -20,7 +20,7 @@ libmanta = { git = "https://github.com/joyent/rust-libmanta", tag = "v0.7.0" }
 mime = "0.3.13"
 moray = { git = "https://github.com/joyent/rust-moray", tag = "v0.9.2" }
 rebalancer = { path = "../rebalancer" }
-reqwest = "0.9.18"
+reqwest = "0.9.24"
 rusqlite = "0.19.0"
 serde = { version = "1.0.91", features = ["derive"] }
 serde_derive = "1.0.91"

--- a/manager/Cargo.toml
+++ b/manager/Cargo.toml
@@ -7,6 +7,7 @@ workspace = ".."
 
 [dependencies]
 clap = "2.33.0"
+crossbeam-queue = "0.2.1"
 crossbeam-channel = "0.3.8"
 crossbeam-deque = "0.7.1"
 futures = "0.1.29"

--- a/manager/Cargo.toml
+++ b/manager/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 workspace = ".."
 
 [dependencies]
+jemallocator = "0.3.2"
 clap = "2.33.0"
 crossbeam-queue = "0.2.1"
 crossbeam-channel = "0.3.8"

--- a/manager/Cargo.toml
+++ b/manager/Cargo.toml
@@ -19,7 +19,7 @@ moray = { git = "https://github.com/joyent/rust-moray", features = ["postgres"],
 sharkspotter = { git = "https://github.com/joyent/rust-sharkspotter", features = ["postgres"], tag = "v0.10.3" }
 diesel = { version = "1.4.2", features = ["postgres"] }
 rand = "0.7.0"
-reqwest = "0.9.18"
+reqwest = "0.9.24"
 strum = "0.16.0"
 strum_macros = "0.16.0"
 uuid = { version = "0.7.4", features = ["v4"] }

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -44,6 +44,7 @@ pub struct ConfigOptions {
     pub max_assignment_size: usize,
     pub max_metadata_update_threads: usize,
     pub max_sharks: usize,
+    pub use_static_md_update_threads: bool,
 }
 
 impl Default for ConfigOptions {
@@ -52,6 +53,7 @@ impl Default for ConfigOptions {
             max_assignment_size: DEFAULT_MAX_ASSIGNMENT_SIZE,
             max_metadata_update_threads: DEFAULT_MAX_METADATA_UPDATE_THREADS,
             max_sharks: DEFAULT_MAX_SHARKS,
+            use_static_md_update_threads: false,
         }
     }
 }

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -30,6 +30,7 @@ static DEFAULT_CONFIG_PATH: &str = "/opt/smartdc/rebalancer/config.json";
 static DEFAULT_MAX_ASSIGNMENT_SIZE: usize = 50;
 static DEFAULT_MAX_METADATA_UPDATE_THREADS: usize = 2;
 static DEFAULT_MAX_SHARKS: usize = 5;
+static DEFAULT_STATIC_QUEUE_DEPTH: usize = 10;
 
 #[derive(Deserialize, Default, Debug, Clone)]
 pub struct Shard {
@@ -45,6 +46,7 @@ pub struct ConfigOptions {
     pub max_metadata_update_threads: usize,
     pub max_sharks: usize,
     pub use_static_md_update_threads: bool,
+    pub static_queue_depth: usize,
 }
 
 impl Default for ConfigOptions {
@@ -54,6 +56,7 @@ impl Default for ConfigOptions {
             max_metadata_update_threads: DEFAULT_MAX_METADATA_UPDATE_THREADS,
             max_sharks: DEFAULT_MAX_SHARKS,
             use_static_md_update_threads: false,
+            static_queue_depth: DEFAULT_STATIC_QUEUE_DEPTH,
         }
     }
 }

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -27,9 +27,23 @@ use std::thread;
 use std::thread::JoinHandle;
 
 static DEFAULT_CONFIG_PATH: &str = "/opt/smartdc/rebalancer/config.json";
+
+// The maximum number of tasks we will send in a single assignment to the agent.
 static DEFAULT_MAX_ASSIGNMENT_SIZE: usize = 50;
+
+// The maximum number of threads that will be used for metadata updates.
+// Each thread has its own hash of moray clients.
 static DEFAULT_MAX_METADATA_UPDATE_THREADS: usize = 2;
+
+// The maximum number of sharks we will use as destinations for things like
+// evacuate job.  This is the top 5 of an ordered list which could mean a
+// different set of sharks each time we get a snapshot from the storinfo zone.
 static DEFAULT_MAX_SHARKS: usize = 5;
+
+// The number of elements the bounded metadata update queue will be set to.
+// For evacuate jobs this represents the number of assignments that can be in
+// the post processing state waiting for a metadata update thread to become
+// available.
 static DEFAULT_STATIC_QUEUE_DEPTH: usize = 10;
 
 #[derive(Deserialize, Default, Debug, Clone)]

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -135,6 +135,7 @@ impl Config {
                             .expect("Lock snaplink_cleanup_required");
 
                         *slcr = new_config;
+                        debug!("Configuration has been updated: {:#?}", *slcr);
                     }
                     Err(e) => {
                         warn!(

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -646,6 +646,8 @@ impl EvacuateJob {
                 // TODO: should we panic? if so just replace with expect()
                 panic!("{}", e);
             });
+
+        self.remove_assignment_from_cache(assign_id);
     }
 
     // Removes assignment cache entry from cache.  The cache entry is

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -2419,7 +2419,8 @@ fn start_assignment_checker(
 
                 // TODO: MANTA-5106
                 if found_assignment_count == 0 {
-                    thread::sleep(Duration::from_millis(200));
+                    trace!("all assignments are running, sleeping for 100ms");
+                    thread::sleep(Duration::from_millis(100));
                 }
             }
             Ok(())

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -2277,6 +2277,7 @@ fn start_assignment_checker(
         .spawn(move || {
             let mut run = true;
             loop {
+                let mut found_assignment_count = 0;
                 if run {
                     run = match checker_fini_rx.try_recv() {
                         Ok(_) => {
@@ -2388,6 +2389,8 @@ fn start_assignment_checker(
                         _ => continue,
                     }
 
+                    found_assignment_count += 1;
+
                     // Mark the shark associated with this assignment as Ready
                     job_action.mark_dest_shark(
                         &ace.dest_shark.manta_storage_id,
@@ -2417,7 +2420,9 @@ fn start_assignment_checker(
                 }
 
                 // TODO: MANTA-5106
-                thread::sleep(Duration::from_secs(1));
+                if found_assignment_count == 0 {
+                    thread::sleep(Duration::from_millis(200));
+                }
             }
             Ok(())
         })

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -597,10 +597,6 @@ impl EvacuateJob {
                 set_run_error(&mut ret, e);
             });
 
-        trace!("Evacuate Job Finished.  Assignments: {}",
-            job_action.assignments.read().expect("assignment read").len()
-        );
-
         drop(job_action);
 
         ret
@@ -1161,10 +1157,7 @@ impl PostAssignment for EvacuateJob {
         );
 
         trace!("Sending {:#?} to {}", payload, agent_uri);
-        let res = match self.post_client
-            .post(&agent_uri)
-            .json(&payload)
-            .send()
+        let res = match self.post_client.post(&agent_uri).json(&payload).send()
         {
             Ok(r) => r,
             Err(e) => {

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -2491,6 +2491,11 @@ fn metadata_update_worker_static(
                     match msg {
                         UpdateWorkerMsg::Data(d) => d,
                         UpdateWorkerMsg::Stop => {
+                            debug!(
+                                "metadata update worker {:?} received STOP, \
+                                exiting", thread::current().id()
+                            );
+
                             break;
                         }
                     }
@@ -2554,6 +2559,8 @@ fn metadata_update_worker_one (
     );
 
     trace!("Updating metadata for {} objects", objects.len());
+
+    client_hash.shrink_to_fit();
 
     for eobj in objects {
         let etag = eobj.etag.clone();
@@ -2802,7 +2809,8 @@ fn metadata_update_broker_static(
         .spawn(move || {
 
             let num_threads = job_action.options.max_metadata_update_threads;
-            let queue = ArrayQueue::new(5);
+            let queue_depth = job_action.options.static_queue_depth;
+            let queue = ArrayQueue::new(queue_depth);
             let q_back = Arc::new(queue);
             let mut thread_handles = vec![];
 

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -671,6 +671,10 @@ impl EvacuateJob {
             entry.is_some(),
             format!("Remove assignment not in hash: {}", assignment_id)
         );
+
+        drop(entry);
+
+        assignments.shrink_to_fit();
     }
 
     fn skip_object(

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -2490,6 +2490,7 @@ fn metadata_update_worker_static(
         );
 
         loop {
+            trace!("Getting assignment");
             let ace = match queue_front.pop() {
                 Ok(msg) => {
                     match msg {
@@ -2506,12 +2507,18 @@ fn metadata_update_worker_static(
                 },
                 Err(PopError) => {
                     // XXX use mio?
+                    trace!("Empty Queue, sleeping");
                     thread::sleep(std::time::Duration::from_millis(100));
                     continue;
                 },
             };
+            let id = ace.id.clone();
+            trace!("Got assignment {}", id);
 
-            metadata_update_worker_one(&job_action,ace, &mut client_hash);
+            metadata_update_worker_one(&job_action, ace, &mut client_hash);
+
+            trace!("Assignment Metdata Update Complete: {}", id);
+
         }
     }
 }

--- a/manager/src/jobs/mod.rs
+++ b/manager/src/jobs/mod.rs
@@ -316,6 +316,8 @@ impl Assignment {
     }
 }
 
+pub type AssignmentCache = HashMap<AssignmentId, AssignmentCacheEntry>;
+
 #[derive(Clone, Debug)]
 pub struct AssignmentCacheEntry {
     id: AssignmentId,
@@ -331,6 +333,12 @@ impl From<Assignment> for AssignmentCacheEntry {
             state: assignment.state,
         }
     }
+}
+
+pub fn assignment_cache_usage(assignments: &AssignmentCache) -> usize {
+    assignments.capacity()
+        * (std::mem::size_of::<Assignment>()
+            + std::mem::size_of::<AssignmentId>())
 }
 
 impl Job {

--- a/manager/src/jobs/status.rs
+++ b/manager/src/jobs/status.rs
@@ -80,12 +80,10 @@ pub fn get_status(uuid: Uuid) -> Result<HashMap<String, i64>, StatusError> {
         ret.insert(to_title_case(&status_count.status), status_count.count);
     }
 
-    // The query won't return 0 results, so add them here.
+    // The query won't return statuses with 0 counts, so add them here.
     for status_value in EvacuateObjectStatus::iter() {
-        let status_str = to_title_case(&status_value.to_string());
-        if !ret.contains_key(&status_str) {
-            ret.insert(status_str, 0);
-        }
+        ret.entry(to_title_case(&status_value.to_string()))
+            .or_insert(0);
     }
 
     ret.insert("Total".into(), total_count);

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -401,7 +401,7 @@ fn main() {
     let config_watcher_handle =
         Config::start_config_watcher(Arc::clone(&config), config_file);
 
-    gotham::start_with_num_threads(addr, router(Arc::clone(&config)), 2);
+    gotham::start_with_num_threads(addr, router(Arc::clone(&config)), 1);
 
     config_watcher_handle.join().expect("join config watcher");
 }

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -401,7 +401,7 @@ fn main() {
     let config_watcher_handle =
         Config::start_config_watcher(Arc::clone(&config), config_file);
 
-    gotham::start_with_num_threads(addr, router(Arc::clone(&config)), 1);
+    gotham::start_with_num_threads(addr, router(Arc::clone(&config)), 2);
 
     config_watcher_handle.join().expect("join config watcher");
 }

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -17,7 +17,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate rebalancer;
 
-
 // jemallocactor drastically improves our memory footprint
 use jemallocator::Jemalloc;
 #[global_allocator]

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -17,7 +17,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate rebalancer;
 
-// jemallocactor drastically improves our memory footprint
+// JEmallocator drastically improves our memory footprint
 use jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -17,6 +17,12 @@ extern crate serde_derive;
 #[macro_use]
 extern crate rebalancer;
 
+
+// jemallocactor drastically improves our memory footprint
+use jemallocator::Jemalloc;
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 use manager::config::Config;
 use manager::jobs::status::StatusError;
 use manager::jobs::{self, JobBuilder, JobDbEntry};

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -401,7 +401,7 @@ fn main() {
     let config_watcher_handle =
         Config::start_config_watcher(Arc::clone(&config), config_file);
 
-    gotham::start(addr, router(Arc::clone(&config)));
+    gotham::start_with_num_threads(addr, router(Arc::clone(&config)), 1);
 
     config_watcher_handle.join().expect("join config watcher");
 }

--- a/manager/src/main.rs
+++ b/manager/src/main.rs
@@ -74,7 +74,7 @@ fn invalid_server_error(state: &State, msg: String) -> Response<Body> {
 }
 
 type GetJobFuture =
-    Box<dyn Future<Item = HashMap<String, usize>, Error = StatusError> + Send>;
+    Box<dyn Future<Item = HashMap<String, i64>, Error = StatusError> + Send>;
 
 fn get_status(uuid: Uuid) -> GetJobFuture {
     Box::new(match jobs::status::get_status(uuid) {

--- a/manager/src/moray_client.rs
+++ b/manager/src/moray_client.rs
@@ -36,13 +36,13 @@ fn get_srv_record(svc: &str, proto: &str, host: &str) -> Result<Srv, Error> {
     r.resolve_record::<Srv>(&query)?
         .choose(&mut rand::thread_rng())
         .map(|r| r.to_owned())
-        .ok_or(
+        .ok_or_else(|| {
             InternalError::new(
                 Some(InternalErrorCode::IpLookupError),
                 "SRV Lookup returned success with 0 IPs",
             )
-            .into(),
-        )
+            .into()
+        })
 }
 
 fn lookup_ip(host: &str) -> Result<IpAddr, Error> {

--- a/manager/src/storinfo.rs
+++ b/manager/src/storinfo.rs
@@ -11,7 +11,7 @@
 use quickcheck::{Arbitrary, Gen};
 use quickcheck_helpers::random::string as random_string;
 use rebalancer::error::Error;
-use reqwest::{self, StatusCode};
+use reqwest::{self, StatusCode, Client};
 use serde::{Deserialize, Serialize};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -117,9 +117,10 @@ impl Storinfo {
 
     /// Populate the storinfo's sharks field, and start the storinfo updater thread.
     pub fn start(&mut self) -> Result<(), Error> {
+        let client = Client::new();
         let mut locked_sharks = self.sharks.lock().unwrap();
         // TODO: MANTA-4961, don't start job if picker cannot be reached.
-        *locked_sharks = Some(fetch_sharks(&self.host));
+        *locked_sharks = Some(fetch_sharks(&client, &self.host));
 
         let handle = Self::updater(
             self.host.clone(),
@@ -156,10 +157,11 @@ impl Storinfo {
 
         thread::spawn(move || {
             let sleep_time = time::Duration::from_secs(10);
+            let client = Client::new();
             while keep_running.load(Ordering::Relaxed) {
                 thread::sleep(sleep_time);
 
-                let mut new_sharks = fetch_sharks(&host);
+                let mut new_sharks = fetch_sharks(&client, &host);
                 new_sharks.sort_by(|a, b| a.available_mb.cmp(&b.available_mb));
 
                 let mut old_sharks = updater_sharks.lock().unwrap();
@@ -185,7 +187,7 @@ pub trait SharkSource: Sync + Send {
     fn choose(&self, algo: &ChooseAlgorithm) -> Option<Vec<StorageNode>>;
 }
 
-fn fetch_sharks(host: &str) -> Vec<StorageNode> {
+fn fetch_sharks(client: &Client, host: &str) -> Vec<StorageNode> {
     let mut new_sharks = vec![];
     let mut done = false;
     let mut after_id = String::new();
@@ -194,7 +196,7 @@ fn fetch_sharks(host: &str) -> Vec<StorageNode> {
 
     while !done {
         let url = format!("{}?limit={}&after_id={}", base_url, limit, after_id);
-        let mut response = match reqwest::get(&url) {
+        let mut response = match client.get(&url).send() {
             Ok(r) => r,
             Err(e) => {
                 error!(

--- a/manager/src/storinfo.rs
+++ b/manager/src/storinfo.rs
@@ -11,7 +11,7 @@
 use quickcheck::{Arbitrary, Gen};
 use quickcheck_helpers::random::string as random_string;
 use rebalancer::error::Error;
-use reqwest::{self, StatusCode, Client};
+use reqwest::{self, Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use std::sync::{
     atomic::{AtomicBool, Ordering},


### PR DESCRIPTION
MANTA-5161 rebalancer status query could be more memory efficient
MANTA-5162 rebalancer only needs one gotham thread
MANTA-5164 rebalancer should remove skipped assignment from hash
MANTA-5168 rebalancer should use jemallocator 
MANTA-5169 rebalancer should use persistent reqwest clients 
MANTA-5100 rebalancer logging clean up
