### PR TITLE
MANTA-5122 - rebalancer-agent should run as nobody rather than root

### DIFF
--- a/smf/manifests/rebalancer-agent.xml
+++ b/smf/manifests/rebalancer-agent.xml
@@ -7,7 +7,7 @@
 -->
 
 <!--
-    Copyright 2019 Joyent, Inc.
+    Copyright 2020 Joyent, Inc.
 -->
 
 <service_bundle type="manifest" name="rebalancer-agent">

--- a/smf/manifests/rebalancer-agent.xml
+++ b/smf/manifests/rebalancer-agent.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0'?>
-<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,27 +10,30 @@
     Copyright 2019 Joyent, Inc.
 -->
 
-<service_bundle type='manifest' name='export'>
-  <service name='manta/application/rebalancer-agent' type='service' version='0'>
-    <create_default_instance enabled='true'/>
-    <dependency name='network' grouping='require_all' restart_on='error' type='service'>
-      <service_fmri value='svc:/network/physical'/>
-    </dependency>
-    <dependency name='filesystem' grouping='require_all' restart_on='error' type='service'>
-      <service_fmri value='svc:/system/filesystem/local'/>
-    </dependency>
-    <exec_method name='start' type='method' exec='/opt/smartdc/rebalancer-agent/bin/rebalancer-agent &amp;' timeout_seconds='30'>
-       <method_context>
-	<method_credential user='nobody' group='nobody' privileges='basic,net_privaddr'/>
-       </method_context>
-    </exec_method>
+<service_bundle type="manifest" name="rebalancer-agent">
+    <service name="manta/application/rebalancer-agent" type="service" version="1">
 
-    <exec_method name='stop' type='method' exec=':kill' timeout_seconds='30'/>
-    <stability value='Unstable'/>
-    <template>
-      <common_name>
-        <loctext xml:lang='C'>Manta Rebalancer Agent</loctext>
-      </common_name>
-    </template>
-  </service>
+        <dependency name="network" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/network/physical" />
+        </dependency>
+        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/system/filesystem/local" />
+        </dependency>
+
+	<exec_method type="method" name="start" exec="/opt/smartdc/rebalancer-agent/bin/rebalancer-agent &amp;" timeout_seconds="30" >
+	    <method_context>
+                <method_credential user='nobody' group='nobody' privileges='basic,net_privaddr'/>
+            </method_context>
+        </exec_method>			
+        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="30" />
+
+        <instance name="default" enabled="true" />
+
+        <stability value='Unstable' />
+
+        <template>
+            <common_name><loctext xml:lang="C">Manta Rebalancer Agent</loctext></common_name>
+        </template>
+
+    </service>
 </service_bundle>

--- a/smf/manifests/rebalancer-agent.xml
+++ b/smf/manifests/rebalancer-agent.xml
@@ -1,5 +1,15 @@
 <?xml version='1.0'?>
 <!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<!--
+    Copyright 2019 Joyent, Inc.
+-->
+
 <service_bundle type='manifest' name='export'>
   <service name='manta/application/rebalancer-agent' type='service' version='0'>
     <create_default_instance enabled='true'/>

--- a/smf/manifests/rebalancer-agent.xml
+++ b/smf/manifests/rebalancer-agent.xml
@@ -1,35 +1,26 @@
-<?xml version="1.0"?>
-<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
-<!--
-    This Source Code Form is subject to the terms of the Mozilla Public
-    License, v. 2.0. If a copy of the MPL was not distributed with this
-    file, You can obtain one at http://mozilla.org/MPL/2.0/.
--->
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='export'>
+  <service name='manta/application/rebalancer-agent' type='service' version='0'>
+    <create_default_instance enabled='true'/>
+    <dependency name='network' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/network/physical'/>
+    </dependency>
+    <dependency name='filesystem' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/system/filesystem/local'/>
+    </dependency>
+    <exec_method name='start' type='method' exec='/opt/smartdc/rebalancer-agent/bin/rebalancer-agent &amp;' timeout_seconds='30'>
+       <method_context>
+	<method_credential user='nobody' group='nobody' privileges='basic,net_privaddr'/>
+       </method_context>
+    </exec_method>
 
-<!--
-    Copyright 2019 Joyent, Inc.
--->
-
-<service_bundle type="manifest" name="rebalancer-agent">
-    <service name="manta/application/rebalancer-agent" type="service" version="1">
-
-        <dependency name="network" grouping="require_all" restart_on="error" type="service">
-            <service_fmri value="svc:/network/physical" />
-        </dependency>
-        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
-            <service_fmri value="svc:/system/filesystem/local" />
-        </dependency>
-
-        <exec_method type="method" name="start" exec="/opt/smartdc/rebalancer-agent/bin/rebalancer-agent &amp;" timeout_seconds="30" />
-        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="30" />
-
-        <instance name="default" enabled="true" />
-
-        <stability value='Unstable' />
-
-        <template>
-            <common_name><loctext xml:lang="C">Manta Rebalancer Agent</loctext></common_name>
-        </template>
-
-    </service>
+    <exec_method name='stop' type='method' exec=':kill' timeout_seconds='30'/>
+    <stability value='Unstable'/>
+    <template>
+      <common_name>
+        <loctext xml:lang='C'>Manta Rebalancer Agent</loctext>
+      </common_name>
+    </template>
+  </service>
 </service_bundle>


### PR DESCRIPTION
Just a minor change in the smf for rebalancer-agent. This should run as nobody rather than root to avoid permission issues on target storage nodes