### PR TITLE
MANTA-5203 rebalancer should not automatically send assignments for every shark update

### DIFF
--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -558,7 +558,9 @@ mod tests {
         File::open(TEST_CONFIG_FILE)
             .and_then(|mut f| {
                 let mut config_file = String::new();
+
                 f.read_to_string(&mut config_file).expect("config file");
+
                 assert!(config_file.contains("options"));
                 assert!(config_file.contains("max_tasks_per_assignment"));
                 assert!(config_file.contains("max_metadata_update_threads"));
@@ -566,6 +568,7 @@ mod tests {
                 assert!(config_file.contains("use_static_md_update_threads"));
                 assert!(config_file.contains("static_queue_depth"));
                 assert!(config_file.contains("max_assignment_age"));
+
                 Ok(())
             })
             .expect("config_basic_test");

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -465,7 +465,7 @@ mod tests {
     use libc;
     use mustache::{Data, MapBuilder};
     use std::fs::File;
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::{Read, Write};
 
     static TEST_CONFIG_FILE: &str = "config.test.json";
 
@@ -556,16 +556,16 @@ mod tests {
         assert_eq!(config.listen_port, 80);
 
         File::open(TEST_CONFIG_FILE)
-            .and_then(|f| {
-                for line in BufReader::new(f).lines() {
-                    let l = line.expect("line reader");
-                    println!("{}", l);
-
-                    assert!(!l.contains("options"));
-                    assert!(!l.contains("max_tasks_per_assignment"));
-                    assert!(!l.contains("max_metadata_update_threads"));
-                    assert!(!l.contains("max_sharks"));
-                }
+            .and_then(|mut f| {
+                let mut config_file = String::new();
+                f.read_to_string(&mut config_file).expect("config file");
+                assert!(config_file.contains("options"));
+                assert!(config_file.contains("max_tasks_per_assignment"));
+                assert!(config_file.contains("max_metadata_update_threads"));
+                assert!(config_file.contains("max_sharks"));
+                assert!(config_file.contains("use_static_md_update_threads"));
+                assert!(config_file.contains("static_queue_depth"));
+                assert!(config_file.contains("max_assignment_age"));
                 Ok(())
             })
             .expect("config_basic_test");

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -29,7 +29,7 @@ use std::thread::JoinHandle;
 static DEFAULT_CONFIG_PATH: &str = "/opt/smartdc/rebalancer/config.json";
 
 // The maximum number of tasks we will send in a single assignment to the agent.
-static DEFAULT_MAX_ASSIGNMENT_SIZE: usize = 50;
+static DEFAULT_MAX_TASKS_PER_ASSIGNMENT: usize = 50;
 
 // The maximum number of threads that will be used for metadata updates.
 // Each thread has its own hash of moray clients.
@@ -62,7 +62,7 @@ pub struct Shard {
 #[derive(Deserialize, Debug, Clone, Copy)]
 #[serde(default)]
 pub struct ConfigOptions {
-    pub max_assignment_size: usize,
+    pub max_tasks_per_assignment: usize,
     pub max_metadata_update_threads: usize,
     pub max_sharks: usize,
     pub use_static_md_update_threads: bool,
@@ -73,7 +73,7 @@ pub struct ConfigOptions {
 impl Default for ConfigOptions {
     fn default() -> ConfigOptions {
         ConfigOptions {
-            max_assignment_size: DEFAULT_MAX_ASSIGNMENT_SIZE,
+            max_tasks_per_assignment: DEFAULT_MAX_TASKS_PER_ASSIGNMENT,
             max_metadata_update_threads: DEFAULT_MAX_METADATA_UPDATE_THREADS,
             max_sharks: DEFAULT_MAX_SHARKS,
             use_static_md_update_threads: true,
@@ -562,7 +562,7 @@ mod tests {
                     println!("{}", l);
 
                     assert!(!l.contains("options"));
-                    assert!(!l.contains("max_assignment_size"));
+                    assert!(!l.contains("max_tasks_per_assignment"));
                     assert!(!l.contains("max_metadata_update_threads"));
                     assert!(!l.contains("max_sharks"));
                 }
@@ -579,7 +579,7 @@ mod tests {
 
         let file_contents = r#"{
                 "options": {
-                    "max_assignment_size": 1111,
+                    "max_tasks_per_assignment": 1111,
                     "max_metadata_update_threads": 2222,
                     "max_sharks": 3333
                 },
@@ -595,7 +595,7 @@ mod tests {
         std::fs::remove_file(TEST_CONFIG_FILE).unwrap_or(());
         let config = write_config_file(file_contents.as_bytes());
 
-        assert_eq!(config.options.max_assignment_size, 1111);
+        assert_eq!(config.options.max_tasks_per_assignment, 1111);
         assert_eq!(config.options.max_metadata_update_threads, 2222);
         assert_eq!(config.options.max_sharks, 3333);
 

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -46,6 +46,12 @@ static DEFAULT_MAX_SHARKS: usize = 5;
 // available.
 static DEFAULT_STATIC_QUEUE_DEPTH: usize = 10;
 
+// The maximum amount of time in seconds that an assignment should remain in
+// memory before it is posted to an agent.  This is not a hard and fast rule.
+// This will only be checked synchronously every time we gather another set of
+// destination sharks.
+static DEFAULT_MAX_ASSIGNMENT_AGE: u64 = 600;
+
 #[derive(Deserialize, Default, Debug, Clone)]
 pub struct Shard {
     pub host: String,
@@ -61,6 +67,7 @@ pub struct ConfigOptions {
     pub max_sharks: usize,
     pub use_static_md_update_threads: bool,
     pub static_queue_depth: usize,
+    pub max_assignment_age: u64,
 }
 
 impl Default for ConfigOptions {
@@ -71,6 +78,7 @@ impl Default for ConfigOptions {
             max_sharks: DEFAULT_MAX_SHARKS,
             use_static_md_update_threads: true,
             static_queue_depth: DEFAULT_STATIC_QUEUE_DEPTH,
+            max_assignment_age: DEFAULT_MAX_ASSIGNMENT_AGE,
         }
     }
 }

--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -598,6 +598,15 @@ mod tests {
         assert_eq!(config.options.max_tasks_per_assignment, 1111);
         assert_eq!(config.options.max_metadata_update_threads, 2222);
         assert_eq!(config.options.max_sharks, 3333);
+        assert_eq!(config.options.use_static_md_update_threads, true);
+        assert_eq!(
+            config.options.static_queue_depth,
+            DEFAULT_STATIC_QUEUE_DEPTH
+        );
+        assert_eq!(
+            config.options.max_assignment_age,
+            DEFAULT_MAX_ASSIGNMENT_AGE
+        );
 
         config_fini();
     }

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -1984,7 +1984,6 @@ where
                 // because we have seen that results in many single
                 // object/task assignments.
                 _flush_shark_assignment_threads(&mut shark_hash);
-
             }
 
             // Flush all the threads first so that while we are joining they

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -1864,6 +1864,8 @@ where
                     remove_keys.push(key.clone());
                 }
 
+                // Send the stop command which flushes any outstanding
+                // assignments, then join the threads
                 _stop_join_some_assignment_threads(
                     &mut shark_hash,
                     remove_keys,
@@ -1906,7 +1908,7 @@ where
                 //      * find first shark that is a vaild destination
                 //      * send object to that shark's thread
                 // end loop
-                for _ in 0..max_assignment_size {
+                for _ in 0..max_assignment_size * max_sharks {
                     // Get an object
                     let mut eobj = match obj_rx.recv() {
                         Ok(obj) => {
@@ -1976,12 +1978,13 @@ where
                     }
                 }
 
-                // We have hit our maximum number of objects we want to
-                // have outstanding so send flush msg to all sharks.
-                // This is to ensure that we don't have an assignment
-                // hanging around with a single object on it just waiting to hit
-                // it's per assignment max, which may never come.
+                // This is a conditional check.  If a given assignment is older
+                // than MAX_ASSIGNMENT_AGE, then we will post it.  But we
+                // don't want to unconditionally post assignments here
+                // because we have seen that results in many single
+                // object/task assignments.
                 _flush_shark_assignment_threads(&mut shark_hash);
+
             }
 
             // Flush all the threads first so that while we are joining they
@@ -2040,8 +2043,10 @@ fn shark_assignment_generator(
 ) -> impl Fn() -> Result<(), Error> {
     move || {
         let max_tasks = job_action.max_tasks_per_assignment;
+        let max_age = job_action.options.max_assignment_age;
         let from_shark_host = job_action.from_shark.manta_storage_id.clone();
         let mut assignment = Assignment::new(shark.clone());
+        let mut assignment_birth_time = std::time::Instant::now();
         let mut flush = false;
         let mut stop = false;
         let mut eobj_vec = vec![];
@@ -2092,7 +2097,9 @@ fn shark_assignment_generator(
                     stop = true;
                 }
                 AssignmentMsg::Flush => {
-                    flush = true;
+                    if assignment_birth_time.elapsed().as_secs() > max_age {
+                        flush = true;
+                    }
                 }
                 AssignmentMsg::Data(data) => {
                     let mut eobj = *data;
@@ -2201,6 +2208,7 @@ fn shark_assignment_generator(
                 available_space = (shark.available_mb - assignment_size) / 2;
                 assignment = Assignment::new(shark.clone());
                 assignment.max_size = available_space;
+                assignment_birth_time = std::time::Instant::now();
 
                 eobj_vec = Vec::new();
             }

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -2093,16 +2093,14 @@ fn shark_assignment_generator(
                     stop = true;
                 }
                 AssignmentMsg::Flush => {
-                    if assignment_birth_time.elapsed().as_secs() > max_age {
-                        let assignment_len = assignment.tasks.len();
-
-                        if assignment_len > 0 {
-                            debug!(
-                                "Timeout reached, flushing {} task assignment",
-                                assignment_len
-                            );
-                            flush = true;
-                        }
+                    let assignment_len = assignment.tasks.len();
+                    if assignment_len > 0 &&
+                        assignment_birth_time.elapsed().as_secs() > max_age {
+                        debug!(
+                            "Timeout reached, flushing {} task assignment",
+                            assignment_len
+                        );
+                        flush = true;
                     }
                 }
 

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -453,7 +453,7 @@ impl EvacuateJob {
         from_shark.manta_storage_id = storage_id;
 
         Ok(Self {
-            min_avail_mb: Some(1000),             // TODO: config
+            min_avail_mb: Some(1000), // TODO: config
             dest_shark_list: RwLock::new(HashMap::new()),
             assignments: RwLock::new(HashMap::new()),
             from_shark,
@@ -1815,8 +1815,8 @@ where
         .spawn(move || {
             let mut done = false;
             let max_sharks = job_action.options.max_sharks;
-            let max_tasks_per_assignment = job_action.options
-                .max_tasks_per_assignment;
+            let max_tasks_per_assignment =
+                job_action.options.max_tasks_per_assignment;
 
             let algo = mod_storinfo::DefaultChooseAlgorithm {
                 min_avail_mb: job_action.min_avail_mb,
@@ -2094,8 +2094,9 @@ fn shark_assignment_generator(
                 }
                 AssignmentMsg::Flush => {
                     let assignment_len = assignment.tasks.len();
-                    if assignment_len > 0 &&
-                        assignment_birth_time.elapsed().as_secs() > max_age {
+                    if assignment_len > 0
+                        && assignment_birth_time.elapsed().as_secs() > max_age
+                    {
                         debug!(
                             "Timeout reached, flushing {} task assignment",
                             assignment_len
@@ -2166,6 +2167,13 @@ fn shark_assignment_generator(
                         },
                     );
 
+                    // If this is the first assignment to be added, start the
+                    // clock.  We don't care about the age of 0 task
+                    // assignments.
+                    if assignment.tasks.len() == 1 {
+                        assignment_birth_time = std::time::Instant::now();
+                    }
+
                     assignment.total_size += content_mb;
                     available_space -= content_mb;
 
@@ -2212,7 +2220,6 @@ fn shark_assignment_generator(
                 available_space = (shark.available_mb - assignment_size) / 2;
                 assignment = Assignment::new(shark.clone());
                 assignment.max_size = available_space;
-                assignment_birth_time = std::time::Instant::now();
 
                 eobj_vec = Vec::new();
             }
@@ -2277,8 +2284,11 @@ where
         match assign_rx.recv() {
             Ok(assignment) => {
                 {
-                    trace!("posting {} task assignment: {:#?}",
-                           assignment.tasks.len(), &assignment);
+                    trace!(
+                        "posting {} task assignment: {:#?}",
+                        assignment.tasks.len(),
+                        &assignment
+                    );
 
                     match job_action.post(assignment) {
                         Ok(()) => (),

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -2187,7 +2187,7 @@ fn shark_assignment_generator(
             //      * We have reached the maximum number of tasks per assignment
             if !assignment.tasks.is_empty() && flush
                 || stop
-                || assignment.tasks.len() > max_tasks
+                || assignment.tasks.len() >= max_tasks
             {
                 let assignment_size = assignment.total_size;
 

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -2094,11 +2094,15 @@ fn shark_assignment_generator(
                 }
                 AssignmentMsg::Flush => {
                     if assignment_birth_time.elapsed().as_secs() > max_age {
-                        debug!(
-                            "Timeout reached, flushing {} task assignment",
-                            assignment.tasks.len()
-                        );
-                        flush = true;
+                        let assignment_len = assignment.tasks.len();
+
+                        if assignment_len > 0 {
+                            debug!(
+                                "Timeout reached, flushing {} task assignment",
+                                assignment_len
+                            );
+                            flush = true;
+                        }
                     }
                 }
 

--- a/manager/src/jobs/mod.rs
+++ b/manager/src/jobs/mod.rs
@@ -261,13 +261,11 @@ impl fmt::Debug for Job {
                  assignments: {:#?}, \
                  from_shark: {:#?}, \
                  min_avail_mb: {:#?}, \
-                 max_tasks_per_assignment: {:#?}, \
                  }}",
                 ej.dest_shark_list,
                 ej.assignments,
                 ej.from_shark,
                 ej.min_avail_mb,
-                ej.max_tasks_per_assignment
             ),
             _ => String::new(),
         };

--- a/sapi_manifests/rebalancer/template
+++ b/sapi_manifests/rebalancer/template
@@ -1,10 +1,12 @@
 {
-	"max_tasks_per_assignment": 50,
-	"max_metadata_update_threads": 2,
-	"max_sharks": 5,
-	"use_static_md_update_threads": true,
-	"static_queue_depth": 10,
-	"max_assignment_age": 600,
+    "options": {
+        "max_tasks_per_assignment": 50,
+        "max_metadata_update_threads": 2,
+        "max_sharks": 5,
+        "use_static_md_update_threads": true,
+        "static_queue_depth": 10,
+        "max_assignment_age": 600
+    },
     "domain_name": "{{DOMAIN_NAME}}",
     {{#SNAPLINK_CLEANUP_REQUIRED}}
     "snaplink_cleanup_required": true,

--- a/sapi_manifests/rebalancer/template
+++ b/sapi_manifests/rebalancer/template
@@ -7,6 +7,7 @@
         "static_queue_depth": 10,
         "max_assignment_age": 600
     },
+    "listen_port": 80,
     "domain_name": "{{DOMAIN_NAME}}",
     {{#SNAPLINK_CLEANUP_REQUIRED}}
     "snaplink_cleanup_required": true,

--- a/sapi_manifests/rebalancer/template
+++ b/sapi_manifests/rebalancer/template
@@ -1,4 +1,10 @@
 {
+	"max_tasks_per_assignment": 50,
+	"max_metadata_update_threads": 2,
+	"max_sharks": 5,
+	"use_static_md_update_threads": true,
+	"static_queue_depth": 10,
+	"max_assignment_age": 600,
     "domain_name": "{{DOMAIN_NAME}}",
     {{#SNAPLINK_CLEANUP_REQUIRED}}
     "snaplink_cleanup_required": true,


### PR DESCRIPTION
MANTA-5203 rebalancer should not automatically send assignments for every shark update
MANTA-5240 rebalancer should not allow old assignments to linger post MANTA-5203
MANTA-5239 rebalancer post and assignment generator threads could use better logging
