### PR TITLE
MANTA-5347 rebalancer: bump MAX_TUNABLE_MD_UPDATE_THREADS to 250

### DIFF
--- a/manager/src/config.rs
+++ b/manager/src/config.rs
@@ -52,7 +52,7 @@ static DEFAULT_STATIC_QUEUE_DEPTH: usize = 10;
 // destination sharks.
 static DEFAULT_MAX_ASSIGNMENT_AGE: u64 = 600;
 
-pub const MAX_TUNABLE_MD_UPDATE_THREADS: usize = 100;
+pub const MAX_TUNABLE_MD_UPDATE_THREADS: usize = 250;
 
 #[derive(Deserialize, Default, Debug, Clone)]
 pub struct Shard {
@@ -212,12 +212,14 @@ impl Config {
                                     continue;
                                 }
                             };
-                        let mut slcr = update_config
-                            .lock()
-                            .expect("Lock snaplink_cleanup_required");
+                        let mut config_lock =
+                            update_config.lock().expect("Lock update_config");
 
-                        *slcr = new_config;
-                        debug!("Configuration has been updated: {:#?}", *slcr);
+                        *config_lock = new_config;
+                        debug!(
+                            "Configuration has been updated: {:#?}",
+                            *config_lock
+                        );
                     }
                     Err(e) => {
                         warn!(

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -533,8 +533,10 @@ impl EvacuateJobUpdateMessage {
                 // finger.  It is still possible to set this number higher
                 // but only at the start of a job. See MANTA-5284.
                 if *num_threads > MAX_TUNABLE_MD_UPDATE_THREADS {
-                    return Err(String::from(
-                        "Cannot set metadata update threads above 100",
+                    return Err(format!(
+                        "Cannot set metadata update threads \
+                         above {}",
+                        MAX_TUNABLE_MD_UPDATE_THREADS
                     ));
                 }
             }

--- a/sapi_manifests/rebalancer/template
+++ b/sapi_manifests/rebalancer/template
@@ -68,7 +68,7 @@
     {{/MUSKIE_MAX_UTILIZATION_PCT}}
 
     {{#SNAPLINK_CLEANUP_REQUIRED}}
-    "snaplink_cleanup_required": true,
+    "snaplink_cleanup_required": {{SNAPLINK_CLEANUP_REQUIRED}},
     {{/SNAPLINK_CLEANUP_REQUIRED}}
     "shards": [{{#INDEX_MORAY_SHARDS}}
         {


### PR DESCRIPTION
MANTA-5348 rebalancer template should be specific about the SNAPLINK_CLEANUP_REQUIRED param