### PR TITLE
MANTA-5413 rebalancer should be able to handle duplicate object ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "manager"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "moray 0.11.2 (git+https://github.com/joyent/rust-moray?tag=v0.11.2)",
  "mustache 0.9.0 (git+https://github.com/rjloura/rust-mustache?branch=issue-60)",
+ "postgres 0.17.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_helpers 0.1.0 (git+https://github.com/joyent/rust-quickcheck-helpers.git?tag=v0.1.0)",
@@ -1715,6 +1716,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "postgres"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-postgres 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "postgres-protocol"
@@ -3506,6 +3520,7 @@ dependencies = [
 "checksum pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 "checksum pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+"checksum postgres 0.17.5 (registry+https://github.com/rust-lang/crates.io-index)" = "14d864cf6c2eabf1323afe4145ff273aad1898e4f2a3bcb30347715df8624a07"
 "checksum postgres-protocol 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "81c5b25980f9a9b5ad36e9cdc855530575396d8a57f67e14691a2440ed0d9a90"
 "checksum postgres-types 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3d14b0a4f433b0e0b565bb0fbc0ac9fc3d79ca338ba265ad0e7eef0f3bcc5e94"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"

--- a/manager/Cargo.toml
+++ b/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manager"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Jenkins Agent <jenkins-agent@joyent.com>"]
 edition = "2018"
 workspace = ".."

--- a/manager/Cargo.toml
+++ b/manager/Cargo.toml
@@ -41,6 +41,7 @@ threadpool = "1.7.1"
 resolve = "0.2.0"
 signal-hook = "0.1.13"
 failure = "0.1.8"
+pg = {version = "0.17.5", package = "postgres"}
 
 [dev-dependencies]
 # Unfortuantely there is a long standing bug in mustache version 0.9.0 that has

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -1171,7 +1171,7 @@ impl EvacuateJob {
                 "INSERT INTO duplicates (id, key, shards) \
            VALUES ($1, $2, $3) \
            ON CONFLICT (id)\
-           DO UPDATE SET shards = mantastubs.shards || $4;
+           DO UPDATE SET shards = duplicates.shards || $4;
            ",
                 &[&duplicate.id, &duplicate.key, &duplicate.shards, &new_shard],
             )

--- a/manager/src/jobs/evacuate.rs
+++ b/manager/src/jobs/evacuate.rs
@@ -1203,7 +1203,7 @@ impl EvacuateJob {
 
                 key = manta_object.key;
                 object_id = o.id.to_owned();
-                new_shard = o.shard.clone();
+                new_shard = o.shard;
 
                 count += 1;
 
@@ -1232,7 +1232,7 @@ impl EvacuateJob {
         let duplicate = Duplicate {
             id: object_id,
             key,
-            shards: vec![new_shard.clone(), existing_shard],
+            shards: vec![new_shard, existing_shard],
         };
 
         EvacuateJob::insert_duplicate_object(
@@ -1265,7 +1265,7 @@ impl EvacuateJob {
             .values(obj_list.clone())
             .execute(&*locked_conn);
 
-        while !ret.is_ok() {
+        while ret.is_err() {
             match ret {
                 Err(DatabaseError(
                     DatabaseErrorKind::UniqueViolation,

--- a/manager/src/jobs/status.rs
+++ b/manager/src/jobs/status.rs
@@ -111,8 +111,8 @@ fn get_job_db_conn_common(uuid: &Uuid) -> Result<PgConnection, StatusError> {
 fn get_evacaute_job_status(
     uuid: &Uuid,
 ) -> Result<JobStatusResultsEvacuate, StatusError> {
-    use diesel::dsl::count_star;
     use crate::jobs::evacuate::duplicates::dsl::duplicates;
+    use diesel::dsl::count_star;
 
     let mut ret = HashMap::new();
     let mut total_count: i64 = 0;

--- a/manager/src/jobs/status.rs
+++ b/manager/src/jobs/status.rs
@@ -111,8 +111,12 @@ fn get_job_db_conn_common(uuid: &Uuid) -> Result<PgConnection, StatusError> {
 fn get_evacaute_job_status(
     uuid: &Uuid,
 ) -> Result<JobStatusResultsEvacuate, StatusError> {
+    use diesel::dsl::count_star;
+    use crate::jobs::evacuate::duplicates::dsl::duplicates;
+
     let mut ret = HashMap::new();
     let mut total_count: i64 = 0;
+    let duplicate_count;
     let conn = get_job_db_conn_common(&uuid)?;
 
     // Unfortunately diesel doesn't have GROUP BY support yet, so we do a raw
@@ -138,6 +142,10 @@ fn get_evacaute_job_status(
             .or_insert(0);
     }
 
+    duplicate_count = duplicates.select(count_star()).first(&conn).unwrap_or(0);
+    total_count += duplicate_count;
+
+    ret.insert("Duplicates".into(), duplicate_count);
     ret.insert("Total".into(), total_count);
 
     Ok(ret)


### PR DESCRIPTION
Rebalancer assumes that each object record in the metadata tier will have a unique object ID.  However, as we found out in MANTA-5397, there are some records misplaced records that have been left behind from resharding as far back as at least 2017. 
This creates issues in the rebalancer because we assume that object IDs are unique. But these metadata "duplicates" or "copies" are exactly the same but on different shards (where they don't belong). When rebalancer scans them in it puts each object metadata record into the local database for updating in the metadata tier after download. The problem is we index by object ID, which in a healthy manta deployment, is always unique.
So when we try to insert a metadata record into the local database for which one already exists we panic, and rightfully so, because we don't really know what to do.... which is the right metadata?  Also, we have likely already rebalanced another object and this second one coming in may or may not be from the correct shard.

The goal of this change is to gracefully handle duplicate objects.

Essentially when we have a unique key violation we will put the object into a separate table called "duplicates", and carry on. It will be up to the operator to fix the duplicates and re-run rebalancer.  The rebalancer runs are idempotent.

This is going to be a rapidly developed change, intended to specifically support an urgent OPs need in a mis-configured/unhealthy environment that should be repaired in the next month or so.

I may not even want to integrate this (open to thoughts on that as well), but I do need a binary for OPS to run sometime in the next few days.  At a minimum I'd like some other eyes on this regardless.